### PR TITLE
Helm 2.10 and fix permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ RUN apk --no-cache add \
     py-crcmod \
     py-pip
 
+ENV HOME /tmp
+
 # Install YQ command line reader
 ARG YQ_VERSION=2.5.0
 RUN pip install "yq==$YQ_VERSION"
@@ -61,3 +63,4 @@ COPY lib /testing/lib/
 COPY chart_test.sh /testing/
 
 RUN ln -s /testing/chart_test.sh /usr/local/bin/chart_test.sh
+USER nobody

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/v$KUBECT
     mv kubectl /usr/local/bin/
 
 # Install Helm
-ARG HELM_VERSION=2.9.1
+ARG HELM_VERSION=2.10.0
 RUN curl -LO "https://kubernetes-helm.storage.googleapis.com/helm-v$HELM_VERSION-linux-amd64.tar.gz" && \
     mkdir -p "/usr/local/helm-$HELM_VERSION" && \
     tar -xzf "helm-v$HELM_VERSION-linux-amd64.tar.gz" -C "/usr/local/helm-$HELM_VERSION" && \


### PR DESCRIPTION
Updated Helm to 2.10.0

Fixed an issue when running helm init inside a container with uid:gid instead of a username:
```
docker run --rm -it -u 112:117 gcr.io/kubernetes-charts-ci/chart-testing:v1.0.3 sh 
/ $ helm init
Creating /.helm
Error: Could not create /.helm: mkdir /.helm: permission denied
```