### PR TITLE
Adding ability to skip version increment check

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Note that this must be done before the script is sourced.
 | `LINT_CONF` | Config file for YAML linter | `/testing/etc/lintconf.yaml` (path of default config file in Docker image) |
 | `CHART_YAML_SCHEMA` | YAML schema for `Chart.yaml` | `/testing/etc/chart_schema.yaml` (path of default schema file in Docker image) |
 | `VALIDATE_MAINTAINERS`| If `true`, maintainer names in `Chart.yaml` are validated to be existing Github accounts | `true` |
+| `CHECK_VERSION_INCREMENT`| If `true`, the chart version is checked to be incremented from the version on the remote target branch | `true` |
 | `GITHUB_INSTANCE`| Url of Github instance for maintainer validation | `https://github.com` |
 
 Note that `CHART_DIRS`, `EXCLUDED_CHARTS`, and `CHART_REPOS` must be configured as Bash arrays.

--- a/lib/chartlib.sh
+++ b/lib/chartlib.sh
@@ -26,6 +26,7 @@ readonly TIMEOUT="${TIMEOUT:-300}"
 readonly LINT_CONF="${LINT_CONF:-/testing/etc/lintconf.yaml}"
 readonly CHART_YAML_SCHEMA="${CHART_YAML_SCHEMA:-/testing/etc/chart_schema.yaml}"
 readonly VALIDATE_MAINTAINERS="${VALIDATE_MAINTAINERS:-true}"
+readonly CHECK_VERSION_INCREMENT="${CHECK_VERSION_INCREMENT:-true}"
 readonly GITHUB_INSTANCE="${GITHUB_INSTANCE:-https://github.com}"
 
 # Special handling for arrays
@@ -46,6 +47,7 @@ echo " LINT_CONF=$LINT_CONF"
 echo " CHART_YAML_SCHEMA=$CHART_YAML_SCHEMA"
 echo " VALIDATE_MAINTAINERS=$VALIDATE_MAINTAINERS"
 echo " GITHUB_INSTANCE=$GITHUB_INSTANCE"
+echo " CHECK_VERSION_INCREMENT=$CHECK_VERSION_INCREMENT"
 echo '--------------------------------------------------------------------------------'
 echo
 
@@ -217,7 +219,10 @@ chartlib::validate_chart() {
 
     echo "Validating chart '$chart_dir'..."
 
-    chartlib::check_for_version_bump "$chart_dir" || error=true
+    if [[ "$CHECK_VERSION_INCREMENT" == true ]]; then
+        chartlib::check_for_version_bump "$chart_dir" || error=true
+    fi
+
     chartlib::lint_yaml_file "$chart_dir/Chart.yaml" || error=true
     chartlib::lint_yaml_file "$chart_dir/values.yaml" || error=true
     chartlib::validate_chart_yaml "$chart_dir" || error=true


### PR DESCRIPTION
The use case for this is an environment where every change is not
a new release of a chart. When new releases are created the
increment can be checked while development outside a release
does not need to check for it