### PR TITLE
Return correct exit code when using values files

### DIFF
--- a/lib/chartlib.sh
+++ b/lib/chartlib.sh
@@ -380,15 +380,20 @@ chartlib::get_pods_for_deployment() {
 #   $1 The chart directory
 chartlib::lint_chart_with_all_configs() {
     local chart_dir="${1?Chart directory is required}"
+    local error=
 
     local has_test_values=
     for values_file in "$chart_dir"/ci/*-values.yaml; do
         has_test_values=true
-        chartlib::lint_chart_with_single_config "$chart_dir" "$values_file"
+        chartlib::lint_chart_with_single_config "$chart_dir" "$values_file" || error=true
     done
 
     if [[ -z "$has_test_values" ]]; then
-        chartlib::lint_chart_with_single_config "$chart_dir"
+        chartlib::lint_chart_with_single_config "$chart_dir" || error=true
+    fi
+
+    if [[ -n "$error" ]]; then
+        return 1
     fi
 }
 

--- a/lib/chartlib.sh
+++ b/lib/chartlib.sh
@@ -407,6 +407,7 @@ chartlib::lint_chart_with_all_configs() {
 #   $1 The chart directory
 chartlib::install_chart_with_all_configs() {
     local chart_dir="${1?Chart directory is required}"
+    local error=
     local index=0
 
     # Generate suffix 10 long and cut release name to 16 long, as in case of long release name
@@ -424,14 +425,16 @@ chartlib::install_chart_with_all_configs() {
     local has_test_values=
     for values_file in "$chart_dir"/ci/*-values.yaml; do
         has_test_values=true
-        if ! chartlib::install_chart_with_single_config "$chart_dir" "$release-$index" "$namespace-$index" "$values_file"; then
-            return 1
-        fi
+        chartlib::install_chart_with_single_config "$chart_dir" "$release-$index" "$namespace-$index" "$values_file" || error=true
         ((index += 1))
     done
 
     if [[ -z "$has_test_values" ]]; then
-        chartlib::install_chart_with_single_config "$chart_dir" "$release" "$namespace"
+        chartlib::install_chart_with_single_config "$chart_dir" "$release" "$namespace" || error=true
+    fi
+
+    if [[ -n "$error" ]]; then
+        return 1
     fi
 }
 


### PR DESCRIPTION
The return values from the individual calls to `lint_chart_with_single_config`
are masked by the other operations in the `lint_chart_with_all_configs`
function.

When `helm lint` reports an error to STDERR but the chart is incorrectly
given a success tick and the exit code of `chart_test.sh` is 0 for
success. An example using `quay.io/helmpack/chart-testing:v1.1.0`:

    ==> Linting charts/nomad-server
    [ERROR] templates/: render error in "nomad-server/templates/nomad-server.yaml": template: nomad-server/templates/nomad-server.yaml:55:28: executing "nomad-server/templates/nomad-server.yaml" at <{{template "fullname...>: template "fullname" not defined

    Error: 1 chart(s) linted, 1 chart(s) failed
    --------------------------------------------------------------------------------
     ✔︎ charts/nomad-server
    --------------------------------------------------------------------------------
     dcarley@cci-mbp  ~/p/g/s/g/c/circle-external-services-chart   master  echo $?
    0s

Fix this by copying the pattern used in other functions of tracking
failures in a local boolean variable and using that to determine the
return code at the end of the function. This is the result after:

    ==> Linting charts/nomad-server
    [ERROR] templates/: render error in "nomad-server/templates/nomad-server.yaml": template: nomad-server/templates/nomad-server.yaml:55:28: executing "nomad-server/templates/nomad-server.yaml" at <{{template "fullname...>: template "fullname" not defined

    Error: 1 chart(s) linted, 1 chart(s) failed
    --------------------------------------------------------------------------------
     ✖︎  charts/nomad-server
    --------------------------------------------------------------------------------
     ✘ dcarley@cci-mbp  ~/p/g/s/g/c/circle-external-services-chart   master  echo $?
    1

There are probably other bugs like this. Shell scripting does not
provide safe error handling for these cases and it's difficult to write
unit tests for. This is another good reason why the proposal in #29 to
re-implement in another language is a good idea.