### PR TITLE
Fixes validate maintainers bug inside chart.Testing.LintChart

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -296,9 +296,11 @@ func (t *Testing) LintChart(chart string, valuesFiles []string) TestResult {
 		return result
 	}
 
-	if err := t.ValidateMaintainers(chart); err != nil {
-		result.Error = err
-		return result
+	if t.config.ValidateMaintainers {
+		if err := t.ValidateMaintainers(chart); err != nil {
+			result.Error = err
+			return result
+		}
 	}
 
 	if len(valuesFiles) > 0 {


### PR DESCRIPTION
Mentioned in #54.

I made code changes and added some tests to ensure that this function uses the correct config setting to determine when to validate maintainers.

Please let me know if there's anything that you'd like me to change stylistically or otherwise. I'm happy to make whatever changes are required to get this merged.

