### PR TITLE
Explicitly disable version checks when all or specific charts are tested

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -114,6 +114,11 @@ func LoadConfiguration(cfgFile string, cmd *cobra.Command, bindFlagsFunc ...func
 		cfg.LintConf = cfgFile
 	}
 
+	if len(cfg.Charts) > 0 || cfg.ProcessAllCharts {
+		fmt.Println("Version increment checking disabled.")
+		cfg.CheckVersionIncrement = false
+	}
+
 	printCfg(cfg)
 
 	return cfg, nil


### PR DESCRIPTION
It is already documented that the check is disabled in this case.

Signed-off-by: Reinhard Nägele <unguiculus@gmail.com>