### PR TITLE
Fix readiness check

### DIFF
--- a/pkg/tool/helm.go
+++ b/pkg/tool/helm.go
@@ -68,11 +68,11 @@ func (h Helm) InstallWithValues(chart string, valuesFile string, namespace strin
 		return err
 	}
 
-	if err := h.exec.RunProcess("helm", "test", release, h.extraArgs); err != nil {
+	if err := h.kubectl.WaitForDeployments(namespace); err != nil {
 		return err
 	}
 
-	return h.kubectl.WaitForDeployments(namespace)
+	return h.exec.RunProcess("helm", "test", release, h.extraArgs)
 }
 
 func (h Helm) DeleteRelease(release string) {


### PR DESCRIPTION
Readiness check should happen before tests are executed. Otherwise
the fails if there are tests and test pods match the label selectors
that identify pods. Since test pods have status Completed, they
cause the readiness check to fail.

Signed-off-by: Reinhard Nägele <unguiculus@gmail.com>