### PR TITLE
Reduce Docker Image Size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,41 +1,37 @@
-FROM alpine:3.8
+## BUILDER
+#
+FROM alpine:3.8 as build
 
-RUN apk --no-cache add \
-    curl \
-    git \
-    libc6-compat \
-    openssh-client \
-    python \
-    py-crcmod \
-    py-pip && \
-    pip install --upgrade pip==18.1
-
-# Install a YAML Linter
-ARG YAML_LINT_VERSION=1.12.1
-RUN pip install "yamllint==$YAML_LINT_VERSION"
-
-# Install Yamale YAML schema validator
-ARG YAMALE_VERSION=1.7.0
-RUN pip install "yamale==$YAMALE_VERSION"
-
-# Install kubectl
 ARG KUBECTL_VERSION=v1.12.2
-RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl" && \
-    chmod +x kubectl && \
-    mv kubectl /usr/local/bin/
-
-# Install Helm
 ARG HELM_VERSION=v2.11.0
-RUN curl -LO "https://kubernetes-helm.storage.googleapis.com/helm-$HELM_VERSION-linux-amd64.tar.gz" && \
-    mkdir -p "/usr/local/helm-$HELM_VERSION" && \
-    tar -xzf "helm-$HELM_VERSION-linux-amd64.tar.gz" -C "/usr/local/helm-$HELM_VERSION" && \
-    ln -s "/usr/local/helm-$HELM_VERSION/linux-amd64/helm" /usr/local/bin/helm && \
-    rm -f "helm-$HELM_VERSION-linux-amd64.tar.gz"
+
+WORKDIR /artifacts
 
 # Goreleaser needs to override this because it builds the
 # Dockerfile from a tmp dir with all files to be copied in the root
 ARG dist_dir=dist/linux_amd64
 
-COPY "$dist_dir/chart_schema.yaml" /etc/ct/chart_schema.yaml
-COPY "$dist_dir/lintconf.yaml" /etc/ct/lintconf.yaml
-COPY "$dist_dir/ct" /usr/local/bin/ct
+COPY "$dist_dir/chart_schema.yaml"  "$dist_dir/lintconf.yaml" /etc/ct/
+COPY "$dist_dir/ct" /usr/local/bin/
+
+RUN apk --no-cache add curl && \
+    curl -sLo /artifacts/kubectl "https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl" && \
+    chmod +x kubectl && \
+    curl -sLo /var/tmp/helm.tgz "https://kubernetes-helm.storage.googleapis.com/helm-$HELM_VERSION-linux-amd64.tar.gz" && \
+    tar -xzf /var/tmp/helm.tgz -C /var/tmp && \
+    mv /var/tmp/linux-amd64/helm /artifacts
+
+## WORKER
+#
+FROM python:3.7.1-alpine3.8
+
+ARG YAML_LINT_VERSION=1.12.1
+ARG YAMALE_VERSION=1.7.0
+
+RUN pip install \
+    "yamllint==$YAML_LINT_VERSION" \
+    "yamale==$YAMALE_VERSION" && \
+    rm -rf /lib/apk/ /etc/apk/ /root/cache/
+
+COPY --from=build /artifacts/* /usr/local/bin/
+COPY --from=build /etc/ct/* /etc/ct/


### PR DESCRIPTION
Size

- use the _builder_ pattern
- use the _RUN ... \ && ..._ pattern
- use _COPY item1 item2 ... destination_ pattern
- use a python/alpine image rather than installing python, etc
- remove apk packages that are not required
- remove cache/control file from final image layer

Other Changes

- use cURL flags -sLo to improve output and control local file names

Signed-off-by: Mark Ayers <mark@philoserf.com>