### PR TITLE
Remove external heredoc library dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,14 +2,6 @@
 
 
 [[projects]]
-  branch = "master"
-  digest = "1:6b250e53b3b7b9abd7e62f55875c234d2f8b77b846bff200fecafa2dc09af09a"
-  name = "github.com/MakeNowJust/heredoc"
-  packages = ["."]
-  pruneopts = ""
-  revision = "e9091a26100e9cfb2b6a8f470085bfa541931a91"
-
-[[projects]]
   digest = "1:b856d8248663c39265a764561c1a1a149783f6cc815feb54a1f3a591b91f6eca"
   name = "github.com/Masterminds/semver"
   packages = ["."]
@@ -224,7 +216,6 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
-    "github.com/MakeNowJust/heredoc",
     "github.com/Masterminds/semver",
     "github.com/mitchellh/go-homedir",
     "github.com/pkg/errors",

--- a/app/cmd/docGen.go
+++ b/app/cmd/docGen.go
@@ -16,19 +16,17 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/MakeNowJust/heredoc"
+	"os"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
-	"os"
 )
 
 func newGenerateDocsCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "doc-gen",
-		Short: "Generate documentation",
-		Long: heredoc.Doc(`
-			Generate documentation for all commands
-			to the 'docs' directory.`),
+		Use:    "doc-gen",
+		Short:  "Generate documentation",
+		Long:   "Generate documentation for all commands to the 'docs' directory.",
 		Hidden: true,
 		Run:    generateDocs,
 	}

--- a/app/cmd/install.go
+++ b/app/cmd/install.go
@@ -16,10 +16,10 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/viper"
 	"os"
 
-	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/viper"
+
 	"github.com/helm/chart-testing/pkg/chart"
 	"github.com/helm/chart-testing/pkg/config"
 
@@ -31,20 +31,18 @@ func newInstallCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install",
 		Short: "Install and test a chart",
-		Long: heredoc.Doc(`
-			Run 'helm install' and ' helm test' on
+		Long: `Run 'helm install' and ' helm test' on
 
-			* changed charts (default)
-			* specific charts (--charts)
-			* all charts (--all)
+	* changed charts (default)
+	* specific charts (--charts)
+	* all charts (--all)
 
-			in given chart directories.
+in given chart directories.
 
-			Charts may have multiple custom values files matching the glob pattern
-			'*-values.yaml' in a directory named 'ci' in the root of the chart's
-			directory. The chart is installed and tested for each of these files.
-			If no custom values file is present, the chart is installed and
-			tested with defaults.`),
+Charts may have multiple custom values files matching the glob pattern
+'*-values.yaml' in a directory named 'ci' in the root of the chart's directory.
+The chart is installed and tested for each of these files. If no custom values
+file is present, the chart is installed and tested with defaults.`,
 		Run: install,
 	}
 
@@ -55,13 +53,11 @@ func newInstallCmd() *cobra.Command {
 }
 
 func addInstallFlags(flags *flag.FlagSet) {
-	flags.String("build-id", "", heredoc.Doc(`
-		An optional, arbitrary identifier that is added to the name of the namespace a
-		chart is installed into. In a CI environment, this could be the build number or
-		the ID of a pull request. If not specified, the name of the chart is used`))
-	flags.String("helm-extra-args", "", heredoc.Doc(`
-		Additional arguments for Helm. Must be passed as a single quoted string
-		(e. g. "--timeout 500 --tiller-namespace tiller"`))
+	flags.String("build-id", "", `An optional, arbitrary identifier that is added to the name of the namespace a
+chart is installed into. In a CI environment, this could be the build number or
+the ID of a pull request. If not specified, the name of the chart is used`)
+	flags.String("helm-extra-args", "", `Additional arguments for Helm. Must be passed as a single quoted string
+(e. g. "--timeout 500 --tiller-namespace tiller"`)
 }
 
 func install(cmd *cobra.Command, args []string) {

--- a/app/cmd/lint.go
+++ b/app/cmd/lint.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/MakeNowJust/heredoc"
-
 	"github.com/helm/chart-testing/pkg/chart"
 	"github.com/helm/chart-testing/pkg/config"
 	"github.com/spf13/cobra"
@@ -31,21 +29,19 @@ func newLintCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "lint",
 		Short: "Lint and validate a chart",
-		Long: heredoc.Doc(`
-			Run 'helm lint', version checking, YAML schema validation
-			on 'Chart.yaml', YAML linting on 'Chart.yaml' and 'values.yaml',
-			and maintainer validation on
+		Long: `Run 'helm lint', version checking, YAML schema validation on 'Chart.yaml', YAML
+linting on 'Chart.yaml' and 'values.yaml', and maintainer validation on
 
-			* changed charts (default)
-			* specific charts (--charts)
-			* all charts (--all)
+	* changed charts (default)
+	* specific charts (--charts)
+	* all charts (--all)
 
-			in given chart directories.
+in given chart directories.
 
-			Charts may have multiple custom values files matching the glob pattern
-			'*-values.yaml' in a directory named 'ci' in the root of the chart's
-			directory. The chart is linted for each of these files. If no custom
-			values file is present, the chart is linted with defaults.`),
+Charts may have multiple custom values files matching the glob pattern
+'*-values.yaml' in a directory named 'ci' in the root of the chart's directory.
+The chart is linted for each of these files. If no custom values file is
+present, the chart is linted with defaults.`,
 		Run: lint,
 	}
 
@@ -56,17 +52,12 @@ func newLintCmd() *cobra.Command {
 }
 
 func addLintFlags(flags *flag.FlagSet) {
-	flags.String("lint-conf", "", heredoc.Doc(`
-			The config file for YAML linting. If not specified, 'lintconf.yaml'
-			is searched in the current directory, '$HOME/.ct', and '/etc/ct', in
-			that order`))
-	flags.String("chart-yaml-schema", "", heredoc.Doc(`
-			The schema for chart.yml validation. If not specified, 'chart_schema.yaml'
-			is searched in the current directory, '$HOME/.ct', and '/etc/ct', in
-			that order.`))
-	flags.Bool("validate-maintainers", true, heredoc.Doc(`
-			Enabled validation of maintainer account names in chart.yml (default: true).
-			Works for GitHub, GitLab, and Bitbucket`))
+	flags.String("lint-conf", "", `The config file for YAML linting. If not specified, 'lintconf.yaml' is searched
+in the current directory, '$HOME/.ct', and '/etc/ct', in that order`)
+	flags.String("chart-yaml-schema", "", `The schema for chart.yml validation. If not specified, 'chart_schema.yaml' is
+searched in the current directory, '$HOME/.ct', and '/etc/ct', in that order.`)
+	flags.Bool("validate-maintainers", true, `Enabled validation of maintainer account names in chart.yml (default: true).
+Works for GitHub, GitLab, and Bitbucket`)
 	flags.Bool("check-version-increment", true, "Activates a check for chart version increments (default: true)")
 }
 

--- a/app/cmd/root.go
+++ b/app/cmd/root.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	flag "github.com/spf13/pflag"
@@ -33,14 +32,13 @@ func NewRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ct",
 		Short: "The Helm chart testing tool",
-		Long: heredoc.Doc(`
-			Lint and test
+		Long: `Lint and test
 
-			* changed charts
-			* specific charts
-			* all charts
+* changed charts
+* specific charts
+* all charts
 
-			in given chart directories.`),
+in given chart directories.`,
 	}
 
 	cmd.AddCommand(newLintCmd())
@@ -64,25 +62,18 @@ func addCommonLintAndInstallFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&cfgFile, "config", "", "Config file")
 	flags.String("remote", "origin", "The name of the Git remote used to identify changed charts")
 	flags.String("target-branch", "master", "The name of the target branch used to identify changed charts")
-	flags.Bool("all", false, heredoc.Doc(`
-		Process all charts except those explicitly excluded.
-		Disables changed charts detection and version increment checking`))
-	flags.StringSlice("charts", []string{}, heredoc.Doc(`
-		Specific charts to test. Disables changed charts detection and
-		version increment checking. May be specified multiple times
-		or separate values with commas`))
-	flags.StringSlice("chart-dirs", []string{"charts"}, heredoc.Doc(`
-		Directories containing Helm charts. May be specified multiple times
-		or separate values with commas`))
-	flags.StringSlice("chart-repos", []string{}, heredoc.Doc(`
-		Additional chart repos to add so dependencies can be resolved. May be
-		specified multiple times or separate values with commas`))
-	flags.StringSlice("excluded-charts", []string{}, heredoc.Doc(`
-		Charts that should be skipped. May be specified multiple times
-		or separate values with commas`))
-	flags.Bool("debug", false, heredoc.Doc(`
-		Print CLI calls of external tools to stdout (Note: depending on helm-extra-args
-		passed, this may reveal sensitive data)`))
+	flags.Bool("all", false, `Process all charts except those explicitly excluded. Disables changed charts
+detection and version increment checking`)
+	flags.StringSlice("charts", []string{}, `Specific charts to test. Disables changed charts detection and version increment
+checking. May be specified multiple times or separate values with commas`)
+	flags.StringSlice("chart-dirs", []string{"charts"}, `Directories containing Helm charts. May be specified multiple times or separate
+values with commas`)
+	flags.StringSlice("chart-repos", []string{}, `Additional chart repos to add so dependencies can be resolved. May be specified
+multiple times or separate values with commas`)
+	flags.StringSlice("excluded-charts", []string{}, `Charts that should be skipped. May be specified multiple times or separate
+values with commas`)
+	flags.Bool("debug", false, `Print CLI calls of external tools to stdout (Note: depending on helm-extra-args
+passed, this may reveal sensitive data)`)
 }
 
 func bindFlags(options []string, flagSet *flag.FlagSet, v *viper.Viper) error {


### PR DESCRIPTION
- go already provides the capability natively with multiline strings
- incidental reordering of imports by `goimports` on edited files