### PR TITLE
Lint values files in ci directory

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -284,13 +284,13 @@ func (t *Testing) LintChart(chart string, valuesFiles []string) TestResult {
 		result.Error = err
 		return result
 	}
-	if err := t.linter.YamlLint(chartYaml, t.config.LintConf); err != nil {
-		result.Error = err
-		return result
-	}
-	if err := t.linter.YamlLint(valuesYaml, t.config.LintConf); err != nil {
-		result.Error = err
-		return result
+
+	yamlFiles := append([]string{chartYaml, valuesYaml}, valuesFiles...)
+	for _, yamlFile := range yamlFiles {
+		if err := t.linter.YamlLint(yamlFile, t.config.LintConf); err != nil {
+			result.Error = err
+			return result
+		}
 	}
 
 	if t.config.ValidateMaintainers {


### PR DESCRIPTION
<!--
Thank you for contributing to helm/chart-testing.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

What it says on the tin. 😄I figure it would be best to lint all the values files we know about.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

This introduces 9 new errors for the stable charts:
```
$ ct lint --chart-dirs=stable --all | grep ✖︎
 ✖︎ stable/ethereum > Error waiting for process: exit status 1
 ✖︎ stable/keycloak > Error waiting for process: exit status 1
 ✖︎ stable/kibana > Error waiting for process: exit status 1
 ✖︎ stable/metrics-server > Error waiting for process: exit status 1
 ✖︎ stable/minecraft > Error waiting for process: exit status 1
 ✖︎ stable/mission-control > Error waiting for process: exit status 1
 ✖︎ stable/prometheus-operator > Error waiting for process: exit status 1
 ✖︎ stable/sumologic-fluentd > Error waiting for process: exit status 1
 ✖︎ stable/xray > Error waiting for process: exit status 1
```