### PR TITLE
Truncate names to 63 characters

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -28,6 +28,7 @@ import (
 )
 
 const chars = "1234567890abcdefghijklmnopqrstuvwxyz"
+const maxNameLength = 63
 
 type Maintainer struct {
 	Name  string `yaml:"name"`
@@ -158,11 +159,11 @@ func CreateInstallParams(chart string, buildId string) (release string, namespac
 	release = path.Base(chart)
 	namespace = release
 	if buildId != "" {
-		namespace += buildId
+		namespace = fmt.Sprintf("%s-%s", namespace, buildId)
 	}
 	randomSuffix := RandomString(10)
-	release = fmt.Sprintf("%s-%s", release, randomSuffix)
-	namespace = fmt.Sprintf("%s-%s", namespace, randomSuffix)
+	release = TruncateLeft(fmt.Sprintf("%s-%s", release, randomSuffix), maxNameLength)
+	namespace = TruncateLeft(fmt.Sprintf("%s-%s", namespace, randomSuffix), maxNameLength)
 	return
 }
 
@@ -172,4 +173,12 @@ func PrintDelimiterLine(delimiterChar string) {
 		delim[i] = delimiterChar
 	}
 	fmt.Println(strings.Join(delim, ""))
+}
+
+func TruncateLeft(s string, maxLength int) string {
+	excess := len(s) - maxLength
+	if excess > 0 {
+		return s[excess:]
+	}
+	return s
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"fmt"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -61,6 +62,28 @@ func TestCompareVersions(t *testing.T) {
 	for index, testData := range testDataSlice {
 		t.Run(string(index), func(t *testing.T) {
 			actual, _ := CompareVersions(testData.oldVersion, testData.newVersion)
+			assert.Equal(t, testData.expected, actual)
+		})
+	}
+}
+
+func TestTruncateLeft(t *testing.T) {
+	var testDataSlice = []struct {
+		input     string
+		maxLength int
+		expected  string
+	}{
+		{"way_shorter_than_max_length", 63, "way_shorter_than_max_length"},
+		{"max_length", len("max_length"), "max_length"},
+		{"way_longer_than_max_length", 10, "max_length"},
+		{"one_shorter_than_max_length", len("one_shorter_than_max_length") + 1, "one_shorter_than_max_length"},
+		{"_one_longer_than_max_length", len("_one_longer_than_max_length") - 1, "one_longer_than_max_length"},
+	}
+
+	for index, testData := range testDataSlice {
+		t.Run(string(index), func(t *testing.T) {
+			actual := TruncateLeft(testData.input, testData.maxLength)
+			fmt.Printf("actual: %s,%d, input: %s,%d\n", actual, len(actual), testData.input, testData.maxLength)
 			assert.Equal(t, testData.expected, actual)
 		})
 	}


### PR DESCRIPTION
There are charts with very long names which cause namespace and
release names to exceed the max length of 63 characters. We, thus,
need to truncate long names. Truncation is done from the left in
order to preserve build ids and randomly generated suffixes.
