### PR TITLE
Fix index out of range when files exist in the root of a chart dir

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -408,7 +408,7 @@ func (t *Testing) ComputeChangedChartDirectories() ([]string, error) {
 	var changedChartDirs []string
 	for _, file := range allChangedChartFiles {
 		pathElements := strings.SplitN(filepath.ToSlash(file), "/", 3)
-		if util.StringSliceContains(cfg.ExcludedCharts, pathElements[1]) {
+		if len(pathElements) < 2 || util.StringSliceContains(cfg.ExcludedCharts, pathElements[1]) {
 			continue
 		}
 		dir := path.Join(pathElements[0], pathElements[1])

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -411,7 +411,7 @@ func (t *Testing) ComputeChangedChartDirectories() ([]string, error) {
 		if len(pathElements) < 2 || util.StringSliceContains(cfg.ExcludedCharts, pathElements[1]) {
 			continue
 		}
-		dir := path.Join(pathElements[0], pathElements[1])
+		dir := filepath.Dir(file)
 		// Only add if not already in list and double-check if it is a chart directory
 		if !util.StringSliceContains(changedChartDirs, dir) && t.chartUtils.IsChartDir(dir) {
 			changedChartDirs = append(changedChartDirs, dir)

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -42,6 +42,7 @@ func (g fakeGit) MergeBase(commit1 string, commit2 string) (string, error) {
 
 func (g fakeGit) ListChangedFilesInDirs(commit string, dirs ...string) ([]string, error) {
 	return []string{
+		"fileAtRoot",
 		"incubator/excluded/Chart.yaml",
 		"incubator/excluded/values.yaml",
 		"incubator/bar/README.md",


### PR DESCRIPTION
If the root of a repository is used as the chart dir (`.`) and there are non-empty directories or files, an index out of range will be raised.

fixes #72 
