### PR TITLE
set port in .kube/config file to 6433

### DIFF
--- a/examples/kind/test/e2e-kind.sh
+++ b/examples/kind/test/e2e-kind.sh
@@ -34,7 +34,7 @@ run_kind() {
 
 install_tiller() {
     # Install Tiller with RBAC
-    kubectl -n kube-system create sa tiller 
+    kubectl -n kube-system create sa tiller
     kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
     docker exec "$config_container_id" helm init --service-account tiller
     echo "Wait for Tiller to be up and ready..."
@@ -74,8 +74,8 @@ main() {
     docker exec "$config_container_id" mkdir /root/.kube
     docker cp "$KUBECONFIG" "$config_container_id:/root/.kube/config"
     # Update in kubeconfig from localhost to kind container IP
-    docker exec "$config_container_id" sed -i "s/localhost/$kind_container_ip/g" /root/.kube/config
-    
+    docker exec "$config_container_id" sed -i "s/localhost:.*/$kind_container_ip:6443/g" /root/.kube/config
+
     echo "Add git remote k8s ${CHARTS_REPO}"
     git remote add k8s "${CHARTS_REPO}" &> /dev/null || true
     git fetch k8s master


### PR DESCRIPTION
Signed-off-by: André Bauer <monotek23@gmail.com>

<!--
Thank you for contributing to helm/chart-testing.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
* fixes tiller install error in kind example
`Error: error installing: Post https://172.17.0.2:35017/apis/extensions/v1beta1/namespaces/kube-system/deployments: dial tcp 172.17.0.2:35017: connect: connection refused`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
* Before the change our pipeline failed as tiller could not be installed: 
https://circleci.com/gh/kiwigrid/helm-charts/337

* after changing the port tiller install works (even when the build still fails):
https://circleci.com/gh/kiwigrid/helm-charts/344
