### PR TITLE
Use visitor to bind flags to Viper

### DIFF
--- a/app/cmd/install.go
+++ b/app/cmd/install.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/viper"
-
 	"github.com/MakeNowJust/heredoc"
 	"github.com/helm/chart-testing/pkg/chart"
 	"github.com/helm/chart-testing/pkg/config"
@@ -74,7 +72,7 @@ func addInstallFlags(flags *flag.FlagSet) {
 func install(cmd *cobra.Command, args []string) {
 	fmt.Println("Installing charts...")
 
-	configuration, err := config.LoadConfiguration(cfgFile, cmd, bindRootFlags, bindInstallFlags)
+	configuration, err := config.LoadConfiguration(cfgFile, cmd)
 	if err != nil {
 		fmt.Printf("Error loading configuration: %s\n", err)
 		os.Exit(1)
@@ -93,9 +91,4 @@ func install(cmd *cobra.Command, args []string) {
 	if err != nil {
 		os.Exit(1)
 	}
-}
-
-func bindInstallFlags(flagSet *flag.FlagSet, v *viper.Viper) error {
-	options := []string{"build-id", "helm-extra-args", "namespace", "release-label"}
-	return bindFlags(options, flagSet, v)
 }

--- a/app/cmd/lint.go
+++ b/app/cmd/lint.go
@@ -23,7 +23,6 @@ import (
 	"github.com/helm/chart-testing/pkg/config"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
-	"github.com/spf13/viper"
 )
 
 func newLintCmd() *cobra.Command {
@@ -76,7 +75,7 @@ func addLintFlags(flags *flag.FlagSet) {
 func lint(cmd *cobra.Command, args []string) {
 	fmt.Println("Linting charts...")
 
-	configuration, err := config.LoadConfiguration(cfgFile, cmd, bindRootFlags, bindLintFlags)
+	configuration, err := config.LoadConfiguration(cfgFile, cmd)
 	if err != nil {
 		fmt.Printf("Error loading configuration: %s\n", err)
 		os.Exit(1)
@@ -97,7 +96,3 @@ func lint(cmd *cobra.Command, args []string) {
 	}
 }
 
-func bindLintFlags(flagSet *flag.FlagSet, v *viper.Viper) error {
-	options := []string{"lint-conf", "chart-yaml-schema", "validate-maintainers", "check-version-increment", "validate-chart-schema", "validate-yaml"}
-	return bindFlags(options, flagSet, v)
-}

--- a/app/cmd/lintAndInstall.go
+++ b/app/cmd/lintAndInstall.go
@@ -43,7 +43,7 @@ func newLintAndInstallCmd() *cobra.Command {
 func lintAndInstall(cmd *cobra.Command, args []string) {
 	fmt.Println("Linting and installing charts...")
 
-	configuration, err := config.LoadConfiguration(cfgFile, cmd, bindRootFlags, bindLintFlags, bindInstallFlags)
+	configuration, err := config.LoadConfiguration(cfgFile, cmd)
 	if err != nil {
 		fmt.Printf("Error loading configuration: %s\n", err)
 		os.Exit(1)

--- a/app/cmd/root.go
+++ b/app/cmd/root.go
@@ -21,8 +21,6 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	flag "github.com/spf13/pflag"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -89,18 +87,4 @@ func addCommonLintAndInstallFlags(flags *pflag.FlagSet) {
 	flags.Bool("debug", false, heredoc.Doc(`
 		Print CLI calls of external tools to stdout (Note: depending on helm-extra-args
 		passed, this may reveal sensitive data)`))
-}
-
-func bindFlags(options []string, flagSet *flag.FlagSet, v *viper.Viper) error {
-	for _, option := range options {
-		if err := v.BindPFlag(option, flagSet.Lookup(option)); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func bindRootFlags(flagSet *flag.FlagSet, v *viper.Viper) error {
-	options := []string{"remote", "target-branch", "all", "charts", "chart-dirs", "chart-repos", "helm-repo-extra-args", "excluded-charts", "debug"}
-	return bindFlags(options, flagSet, v)
 }


### PR DESCRIPTION
Simplifies the logic and no longer requires that flags be
listed individually in order to get bound.

Signed-off-by: Reinhard Nägele <unguiculus@gmail.com>
