### PR TITLE
Update kind example

### DIFF
--- a/examples/kind/.circleci/config.yml
+++ b/examples/kind/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   lint-scripts:
     docker:
@@ -6,42 +6,27 @@ jobs:
     steps:
       - checkout
       - run:
-          name: lint
-          command: |
-            shellcheck -x test/e2e-kind.sh
+          command: shellcheck -x test/e2e-kind.sh
+
   lint-charts:
     docker:
       - image: quay.io/helmpack/chart-testing:v2.2.0
     steps:
       - checkout
       - run:
-          name: lint
-          command: |
-            git remote add k8s https://github.com/your_git_repo/charts
-            git fetch k8s master
-            ct lint --config test/ct.yaml
+          command: ct lint --config test/ct.yaml
+
   install-charts:
     machine: true
-    environment:
-      CHART_TESTING_IMAGE: quay.io/helmpack/chart-testing
-      CHART_TESTING_TAG: v2.2.0
-      CHARTS_REPO: https://github.com/your_git_repo/charts
-      K8S_VERSION: "v1.12.3"
     steps:
       - checkout
       - run:
-          name: install
-          command: |
-            test/e2e-kind.sh
-          no_output_timeout: 3600
+          command: test/e2e-kind.sh
+
 workflows:
   version: 2
-  lint_and_install:
+  untagged-build:
     jobs:
       - lint-scripts
-      - lint-charts:
-          requires:
-            - lint-scripts
-      - install-charts:
-          requires:
-            - lint-charts
+      - lint-charts
+      - install-charts

--- a/examples/kind/README.md
+++ b/examples/kind/README.md
@@ -1,5 +1,7 @@
-# Chart testing example with CircleCi and kind - `k`ubernetes `in` `d`ocker
+# Chart testing example with CircleCi and kind - `K`ubernetes `in` `D`ocker
+
+`kind` is a tool for running local Kubernetes clusters using Docker container "nodes".
 
 This example shows how to lint and test charts using CircleCi and [kind](https://github.com/kubernetes-sigs/kind).
-
-`kind` is a tool for running local/CI pipelines Kubernetes clusters using Docker container "nodes".  
+It creates a cluster with a single master node and three worker nodes.
+The cluster configuration can be adjusted in [kind-config.yaml](test/kind-config.yaml).

--- a/examples/kind/test/ct.yaml
+++ b/examples/kind/test/ct.yaml
@@ -1,7 +1,1 @@
-remote: k8s
-target-branch: master
-chart-dirs:
-  - stable
-excluded-charts:
-  - common
 helm-extra-args: --timeout 800

--- a/examples/kind/test/kind-config.yaml
+++ b/examples/kind/test/kind-config.yaml
@@ -1,0 +1,6 @@
+kind: Config
+apiVersion: kind.sigs.k8s.io/v1alpha2
+nodes:
+  - role: control-plane
+  - role: worker
+    replicas: 3


### PR DESCRIPTION
* Use kind release from GitHub instead of 'go get sigs.k8s.io/kind'
* Run ct container with '--network host' to avoid patching kubeconfig
* Create multi-node cluster with one master and three worker nodes
  so pods with anti-affinity can be tested
* Improve wait logic to cater for multiple nodes
* Add log statements
* Remote unnecessary 'k8s' remote to avoid confusion
* Extract function for 'docker exec' calls

Signed-off-by: Reinhard Nägele <unguiculus@gmail.com>
