### PR TITLE
force the namespace deletion by updating the finalizers in the namespace obj

### DIFF
--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -96,3 +96,16 @@ func (p ProcessExecutor) RunProcess(executable string, execArgs ...interface{}) 
 
 	return nil
 }
+
+func (p ProcessExecutor) RunLongRunningProcess(executable string, execArgs ...interface{}) (*exec.Cmd, error) {
+	args, err := util.Flatten(execArgs)
+	if p.debug {
+		fmt.Println(">>>", executable, strings.Join(args, " "))
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "Invalid arguments supplied")
+	}
+	cmd := exec.Command(executable, args...)
+
+	return cmd, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
After the namespace deletion sometimes the namespace get stuck in the `Terminating` phase forever and we need to use the script from @unguiculus (https://gist.github.com/unguiculus/d915e911ba04f1f97ecea4f617a2eef5) to remove the namespaces.

This PR introduces the same login in the bash script to the chart-testing, when we check if the namespace still exists we apply the logic to force remove the namespace.

note: for example, last week in the Helm Chart CI Cluster we had around 900 namespaces in Terminating phase.
