### PR TITLE
force the namespace deletion by updating the finalizers in the namespace obj

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -42,6 +42,22 @@
   version = "v1.4.7"
 
 [[projects]]
+  digest = "1:05334858a0cfb538622a066e065287f63f42bee26a7fda93a789674225057201"
+  name = "github.com/hashicorp/go-cleanhttp"
+  packages = ["."]
+  pruneopts = ""
+  revision = "e8ab9daed8d1ddd2d3c4efba338fe2eeae2e4f18"
+  version = "v0.5.0"
+
+[[projects]]
+  digest = "1:776139dc18d63ef223ffaca5d8e9a3057174890f84393d3c881e934100b66dbc"
+  name = "github.com/hashicorp/go-retryablehttp"
+  packages = ["."]
+  pruneopts = ""
+  revision = "73489d0a1476f0c9e6fb03f9c39241523a496dfd"
+  version = "v0.5.2"
+
+[[projects]]
   digest = "1:d14365c51dd1d34d5c79833ec91413bfbb166be978724f15701e17080dc06dec"
   name = "github.com/hashicorp/hcl"
   packages = [
@@ -235,6 +251,7 @@
   input-imports = [
     "github.com/MakeNowJust/heredoc",
     "github.com/Masterminds/semver",
+    "github.com/hashicorp/go-retryablehttp",
     "github.com/mitchellh/go-homedir",
     "github.com/pkg/errors",
     "github.com/spf13/cobra",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -30,3 +30,7 @@
 [[constraint]]
     name = "gopkg.in/yaml.v2"
     version = "v2.2.1"
+
+[[constraint]]
+    name = "github.com/hashicorp/go-retryablehttp"
+    version = "v0.5.2"

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -96,3 +96,16 @@ func (p ProcessExecutor) RunProcess(executable string, execArgs ...interface{}) 
 
 	return nil
 }
+
+func (p ProcessExecutor) RunLongRunningProcess(executable string, execArgs ...interface{}) (*exec.Cmd, error) {
+	args, err := util.Flatten(execArgs)
+	if p.debug {
+		fmt.Println(">>>", executable, strings.Join(args, " "))
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "Invalid arguments supplied")
+	}
+	cmd := exec.Command(executable, args...)
+
+	return cmd, nil
+}

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -121,10 +121,6 @@ func (p ProcessExecutor) RunWithProxy(withProxy fn) error {
 		return errors.Wrap(err, "Error starting the 'kubectl proxy' process")
 	}
 
-	go func() {
-		cmdProxy.Wait()
-	}()
-
 	err = withProxy(randomPort)
 
 	cmdProxy.Process.Signal(os.Kill)

--- a/pkg/tool/kubectl.go
+++ b/pkg/tool/kubectl.go
@@ -67,7 +67,6 @@ func (k Kubectl) DeleteNamespace(namespace string) {
 }
 
 func (k Kubectl) forceNamespaceDeletion(namespace string) error {
-	fmt.Printf("Removing finalizers from namespace '%s'...\n", namespace)
 	// Getting the namespace json to remove the finalizer
 	cmdOutput, err := k.exec.RunProcessAndCaptureOutput("kubectl", "get", "namespace", namespace, "--output=json")
 	if err != nil {
@@ -90,6 +89,8 @@ func (k Kubectl) forceNamespaceDeletion(namespace string) error {
 
 	// Remove finalizer from the namespace
 	fun := func(port int) error {
+		fmt.Printf("Removing finalizers from namespace '%s'...\n", namespace)
+
 		k8sURL := fmt.Sprintf("http://127.0.0.1:%d/api/v1/namespaces/%s/finalize", port, namespace)
 		req, err := retryablehttp.NewRequest("PUT", k8sURL, bytes.NewReader(namespaceUpdateBytes))
 		if err != nil {

--- a/pkg/tool/kubectl.go
+++ b/pkg/tool/kubectl.go
@@ -1,8 +1,11 @@
 package tool
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -20,13 +23,13 @@ func NewKubectl(exec exec.ProcessExecutor) Kubectl {
 	}
 }
 
-// DeleteNamespace deletes the specified namespace. If the namespace does not terminate within 90s, pods running in the
+// DeleteNamespace deletes the specified namespace. If the namespace does not terminate within 120s, pods running in the
 // namespace and, eventually, the namespace itself are force-deleted.
 func (k Kubectl) DeleteNamespace(namespace string) {
 	fmt.Printf("Deleting namespace '%s'...\n", namespace)
 	timeoutSec := "120s"
 	if err := k.exec.RunProcess("kubectl", "delete", "namespace", namespace, "--timeout", timeoutSec); err != nil {
-		fmt.Printf("Namespace '%s' did not terminate after %s.", namespace, timeoutSec)
+		fmt.Printf("Namespace '%s' did not terminate after %s.\n", namespace, timeoutSec)
 	}
 
 	if _, err := k.exec.RunProcessAndCaptureOutput("kubectl", "get", "namespace", namespace); err != nil {
@@ -34,7 +37,7 @@ func (k Kubectl) DeleteNamespace(namespace string) {
 		return
 	}
 
-	fmt.Printf("Namespace '%s' did not terminate after %s.", namespace, timeoutSec)
+	fmt.Printf("Namespace '%s' did not terminate after %s.\n", namespace, timeoutSec)
 
 	fmt.Println("Force-deleting pods...")
 	if err := k.exec.RunProcess("kubectl", "delete", "pods", "--namespace", namespace, "--all", "--force", "--grace-period=0"); err != nil {
@@ -44,8 +47,65 @@ func (k Kubectl) DeleteNamespace(namespace string) {
 	time.Sleep(3 * time.Second)
 
 	if err := k.exec.RunProcess("kubectl", "get", "namespace", namespace); err != nil {
+		fmt.Printf("Removing finalizers from namespace '%s'...\n", namespace)
+		// Getting the namespace json to remove the finalizer
+		cmdOutput, err := k.exec.RunProcessAndCaptureOutput(
+			"kubectl", "get", "namespace", namespace, "--output=json")
+		if err != nil {
+			fmt.Println("Error getting namespace json:", err)
+			return
+		}
+
+		namespaceUpdate := map[string]interface{}{}
+		err = json.Unmarshal([]byte(cmdOutput), &namespaceUpdate)
+		if err != nil {
+			fmt.Println("Error in unmarshalling the payload:", err)
+			return
+		}
+		namespaceUpdate["spec"] = nil
+		namespaceUpdateByte, err := json.Marshal(namespaceUpdate)
+		if err != nil {
+			fmt.Println("Error in marshalling the payload:", err)
+			return
+		}
+
+		// Start 'kubectl proxy'
+		cmdProxy, err := k.exec.RunLongRunningProcess("kubectl", "proxy")
+		if err != nil {
+			fmt.Println("Error creating the kubectl proxy:", err)
+			return
+		}
+
+		go func() {
+			err = cmdProxy.Start()
+			if err != nil {
+				fmt.Println("Error starting the kubectl proxy:", err)
+				return
+			}
+			err = cmdProxy.Wait()
+			fmt.Printf("Command finished with error: %v", err)
+		}()
+
+		// Update the namespace
+		k8sURL := fmt.Sprintf("http://127.0.0.1:8001/api/v1/namespaces/%s/finalize", namespace)
+		req, err := http.NewRequest("PUT", k8sURL, bytes.NewReader(namespaceUpdateByte))
+		if err != nil {
+			fmt.Println("Error creating the request to update the namespace:", err)
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			fmt.Println("Error updating the namespace:", err)
+			return
+		}
+		defer resp.Body.Close()
+
+		cmdProxy.Process.Signal(os.Kill)
+
 		fmt.Printf("Force-deleting namespace '%s'...\n", namespace)
-		if err := k.exec.RunProcess("kubectl", "delete", "namespace", namespace, "--force", "--grace-period=0"); err != nil {
+		if err := k.exec.RunProcess("kubectl", "delete", "namespace", namespace, "--force", "--grace-period=0", "--ignore-not-found=true"); err != nil {
 			fmt.Println("Error deleting namespace:", err)
 		}
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -21,6 +21,7 @@ import (
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"math/rand"
+	"net"
 	"os"
 	"path"
 	"path/filepath"
@@ -202,4 +203,14 @@ func TruncateLeft(s string, maxLength int) string {
 		return s[excess:]
 	}
 	return s
+}
+
+func GetRandomPort() (int , error) {
+	listener, err := net.Listen("tcp", ":0")
+	defer listener.Close()
+	if err != nil {
+		return 0, err
+	}
+
+	return listener.Addr().(*net.TCPAddr).Port, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
After the namespace deletion sometimes the namespace get stuck in the `Terminating` phase forever and we need to use the script from @unguiculus (https://gist.github.com/unguiculus/d915e911ba04f1f97ecea4f617a2eef5) to remove the namespaces.

This PR introduces the same login in the bash script to the chart-testing, when we check if the namespace still exists we apply the logic to force remove the namespace.

note: for example, last week in the Helm Chart CI Cluster we had around 900 namespaces in Terminating phase.