### PR TITLE
Break docker build if ct is not executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,3 +35,5 @@ RUN curl -LO "https://kubernetes-helm.storage.googleapis.com/helm-$HELM_VERSION-
 COPY ./etc/chart_schema.yaml /etc/ct/chart_schema.yaml
 COPY ./etc/lintconf.yaml /etc/ct/lintconf.yaml
 COPY ct /usr/local/bin/ct
+# Ensure that the binary is available on path and is executable
+RUN ct --help


### PR DESCRIPTION
<!--
Thank you for contributing to helm/chart-testing.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

I think what happened here is that `latest` was built with `docker build .` rather than `build.sh`, and pushed to quay.io. Previously this would have failed when `ct` wasn't found in the build context, but as of a1528a422bebab52029f5014357f2b2a80b7a321 `ct` exists as a directory and is copied without error.

This PR adds a RUN step to ensure that `ct` can execute, causing `docker build .` to fail.

**Which issue this PR fixes**

Prevents #113 (close that issue by building with `build.sh` and pushing again)

**Special notes for your reviewer**:
