### PR TITLE
Set kind node to 1 worker

### DIFF
--- a/examples/kind/test/kind-config.yaml
+++ b/examples/kind/test/kind-config.yaml
@@ -3,4 +3,4 @@ apiVersion: kind.sigs.k8s.io/v1alpha2
 nodes:
   - role: control-plane
   - role: worker
-    replicas: 3
+    replicas: 1


### PR DESCRIPTION
Signed-off-by: rimas <rmocius@gmail.com>

Set kind node to 1 worker, as `host-path` storage provider doesn't work in multi-node