### PR TITLE
add deletion of pv and pvcs

### DIFF
--- a/pkg/tool/kubectl.go
+++ b/pkg/tool/kubectl.go
@@ -24,12 +24,12 @@ func NewKubectl(exec exec.ProcessExecutor) Kubectl {
 // namespace and, eventually, the namespace itself are force-deleted.
 func (k Kubectl) DeleteNamespace(namespace string) {
 
-	fmt.Println("deleting pvcs...")
+	fmt.Println("Deleting pvcs...")
 	if err := k.exec.RunProcess("kubectl", "delete", "pvc", "--namespace", namespace, "--all"); err != nil {
 		fmt.Println("Error deleting pvc(s):", err)
 	}
 
-	fmt.Println("deleting pvs...")
+	fmt.Println("Deleting pvs...")
 	if err := k.exec.RunProcess("kubectl", "delete", "pv", "--namespace", namespace, "--all"); err != nil {
 		fmt.Println("Error deleting pv(s):", err)
 	}

--- a/pkg/tool/kubectl.go
+++ b/pkg/tool/kubectl.go
@@ -23,6 +23,17 @@ func NewKubectl(exec exec.ProcessExecutor) Kubectl {
 // DeleteNamespace deletes the specified namespace. If the namespace does not terminate within 90s, pods running in the
 // namespace and, eventually, the namespace itself are force-deleted.
 func (k Kubectl) DeleteNamespace(namespace string) {
+
+	fmt.Println("deleting pvcs...")
+	if err := k.exec.RunProcess("kubectl", "delete", "pvc", "--namespace", namespace, "--all"); err != nil {
+		fmt.Println("Error deleting pvc(s):", err)
+	}
+
+	fmt.Println("deleting pvs...")
+	if err := k.exec.RunProcess("kubectl", "delete", "pv", "--namespace", namespace, "--all"); err != nil {
+		fmt.Println("Error deleting pv(s):", err)
+	}
+
 	fmt.Printf("Deleting namespace '%s'...\n", namespace)
 	timeoutSec := "120s"
 	if err := k.exec.RunProcess("kubectl", "delete", "namespace", namespace, "--timeout", timeoutSec); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Before we start the namespace cleanup we try to delete any remaining PV/PVC(s) in the namespace.
