### PR TITLE
Fix goreleaser docker.binary deprecation notice

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           name: Install tools
           command: |
             apk add bash build-base ca-certificates curl docker git openssh
-            curl -SLO https://github.com/goreleaser/goreleaser/releases/download/v0.95.2/goreleaser_Linux_x86_64.tar.gz
+            curl -SLO https://github.com/goreleaser/goreleaser/releases/download/v0.102.0/goreleaser_Linux_x86_64.tar.gz
             mkdir -p /usr/local/goreleaser
             tar -xzf goreleaser_Linux_x86_64.tar.gz -C /usr/local/goreleaser
             ln -s /usr/local/goreleaser/goreleaser /usr/local/bin/goreleaser

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,7 +32,8 @@ snapshot:
 dockers:
   - goos: linux
     goarch: amd64
-    binary: ct
+    binaries:
+      - ct
     skip_push: false
     dockerfile: Dockerfile
     image_templates:


### PR DESCRIPTION
<!--
Thank you for contributing to helm/chart-testing.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

Addresses warning message during `build.sh` execution:

```
DEPRECATED: `docker.binary` should not be used anymore, check https://goreleaser.com/deprecations#docker-binary for more info.
```

Link: https://goreleaser.com/deprecations/#docker-binary

**Which issue this PR fixes**

**Special notes for your reviewer**:
