### PR TITLE
add require when testing the install charts

### DIFF
--- a/examples/kind/.circleci/config.yml
+++ b/examples/kind/.circleci/config.yml
@@ -22,6 +22,7 @@ jobs:
       - checkout
       - run:
           command: test/e2e-kind.sh
+          no_output_timeout: 1h
 
 workflows:
   version: 2
@@ -29,4 +30,7 @@ workflows:
     jobs:
       - lint-scripts
       - lint-charts
-      - install-charts
+      - install-charts:
+          requires:
+            - lint-scripts
+            - lint-charts


### PR DESCRIPTION
**What this PR does / why we need it**:
I'm using this example with circleci as well and notice a small change we need to do in order to run the tests by adding the parameter `no_output_timeout`, this make the circle ci wait, because the install chart can take some time without any output and in CCi if no output happen in a short time it will kill the build.

Also added a requirement in the install chart to have the lints all passing before install
