### PR TITLE
Add git version documentation, rename worktree methods, and handle existing worktree

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ It is recommended to use the provided Docker image which can be [found on Quay](
 It comes with all necessary tools installed.
 
 * [helm](http://helm.sh)
+* [git](https://git-scm.com) (2.17.0 or later)
 * [yamllint](https://github.com/adrienverge/yamllint)
 * [yamale](https://github.com/23andMe/Yamale)
 * [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/)

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ It automatically detects charts changed against the target branch.
 It is recommended to use the provided Docker image which can be [found on Quay](https://quay.io/helmpack/chart-testing/).
 It comes with all necessary tools installed.
 
-* [helm](http://helm.sh)
-* [git](https://git-scm.com) (2.17.0 or later)
-* [yamllint](https://github.com/adrienverge/yamllint)
-* [yamale](https://github.com/23andMe/Yamale)
-* [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/)
+* [Helm](http://helm.sh)
+* [Git](https://git-scm.com) (2.17.0 or later)
+* [Yamllint](https://github.com/adrienverge/yamllint)
+* [Yamale](https://github.com/23andMe/Yamale)
+* [Kubectl](https://kubernetes.io/docs/reference/kubectl/overview/)
 
 ### Binary Distribution
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,10 @@ It automatically detects charts changed against the target branch.
 It is recommended to use the provided Docker image which can be [found on Quay](https://quay.io/helmpack/chart-testing/).
 It comes with all necessary tools installed.
 
-* Helm (http://helm.sh)
-* yamllint (https://github.com/adrienverge/yamllint)
-* yamale (https://github.com/23andMe/Yamale)
-* kubectl (https://kubernetes.io/docs/reference/kubectl/overview/)
-* Tooling for your cluster
+* [helm](http://helm.sh)
+* [yamllint](https://github.com/adrienverge/yamllint)
+* [yamale](https://github.com/23andMe/Yamale)
+* [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/)
 
 ### Binary Distribution
 

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -35,9 +35,9 @@ const maxNameLength = 63
 //
 // Show returns the contents of file on the specified remote/branch.
 //
-// AddWorkTree checks out the contents of the repository at a commit ref into the specified path.
+// AddWorktree checks out the contents of the repository at a commit ref into the specified path.
 //
-// RemoveWorkTree removes the working tree at the specified path.
+// RemoveWorktree removes the working tree at the specified path.
 //
 // MergeBase returns the SHA1 of the merge base of commit1 and commit2.
 //
@@ -50,8 +50,8 @@ const maxNameLength = 63
 type Git interface {
 	FileExistsOnBranch(file string, remote string, branch string) bool
 	Show(file string, remote string, branch string) (string, error)
-	AddWorkTree(path string, ref string) error
-	RemoveWorkTree(path string) error
+	AddWorktree(path string, ref string) error
+	RemoveWorktree(path string) error
 	MergeBase(commit1 string, commit2 string) (string, error)
 	ListChangedFilesInDirs(commit string, dirs ...string) ([]string, error)
 	GetUrlForRemote(remote string) (string, error)
@@ -329,11 +329,11 @@ func (t *Testing) processCharts(action func(chart *Chart) TestResult) ([]TestRes
 			return results, errors.Wrap(err, "Could not create previous revision directory")
 		}
 		t.previousRevisionWorkTree = worktreePath
-		err = t.git.AddWorkTree(worktreePath, mergeBase)
+		err = t.git.AddWorktree(worktreePath, mergeBase)
 		if err != nil {
 			return results, errors.Wrap(err, "Could not create worktree for previous revision")
 		}
-		defer t.git.RemoveWorkTree(worktreePath)
+		defer t.git.RemoveWorktree(worktreePath)
 
 		for _, chart := range charts {
 			if err := t.helm.BuildDependencies(t.computePreviousRevisionPath(chart.Path())); err != nil {

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -223,7 +223,7 @@ type Testing struct {
 	accountValidator         AccountValidator
 	directoryLister          DirectoryLister
 	chartUtils               ChartUtils
-	previousRevisionWorkTree string
+	previousRevisionWorktree string
 }
 
 // TestResults holds results and overall status
@@ -257,7 +257,7 @@ func NewTesting(config config.Configuration) Testing {
 // computePreviousRevisionPath converts any file or directory path to the same path in the
 // previous revision's working tree.
 func (t *Testing) computePreviousRevisionPath(fileOrDirPath string) string {
-	return filepath.Join(t.previousRevisionWorkTree, fileOrDirPath)
+	return filepath.Join(t.previousRevisionWorktree, fileOrDirPath)
 }
 
 func (t *Testing) processCharts(action func(chart *Chart) TestResult) ([]TestResult, error) {
@@ -328,7 +328,7 @@ func (t *Testing) processCharts(action func(chart *Chart) TestResult) ([]TestRes
 		if err != nil {
 			return results, errors.Wrap(err, "Could not create previous revision directory")
 		}
-		t.previousRevisionWorkTree = worktreePath
+		t.previousRevisionWorktree = worktreePath
 		err = t.git.AddWorktree(worktreePath, mergeBase)
 		if err != nil {
 			return results, errors.Wrap(err, "Could not create worktree for previous revision")

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -35,9 +35,9 @@ const maxNameLength = 63
 //
 // Show returns the contents of file on the specified remote/branch.
 //
-// AddWorkingTree checks out the contents of the repository at a commit ref into the specified path.
+// AddWorkTree checks out the contents of the repository at a commit ref into the specified path.
 //
-// RemoveWorkingTree removes the working tree at the specified path.
+// RemoveWorkTree removes the working tree at the specified path.
 //
 // MergeBase returns the SHA1 of the merge base of commit1 and commit2.
 //
@@ -50,8 +50,8 @@ const maxNameLength = 63
 type Git interface {
 	FileExistsOnBranch(file string, remote string, branch string) bool
 	Show(file string, remote string, branch string) (string, error)
-	AddWorkingTree(path string, ref string) error
-	RemoveWorkingTree(path string) error
+	AddWorkTree(path string, ref string) error
+	RemoveWorkTree(path string) error
 	MergeBase(commit1 string, commit2 string) (string, error)
 	ListChangedFilesInDirs(commit string, dirs ...string) ([]string, error)
 	GetUrlForRemote(remote string) (string, error)
@@ -324,8 +324,8 @@ func (t *Testing) processCharts(action func(chart *Chart) TestResult) ([]TestRes
 		if err != nil {
 			return results, errors.Wrap(err, "Error identifying merge base")
 		}
-		t.git.AddWorkingTree(ctPreviousRevisionTree, mergeBase)
-		defer t.git.RemoveWorkingTree(ctPreviousRevisionTree)
+		t.git.AddWorkTree(ctPreviousRevisionTree, mergeBase)
+		defer t.git.RemoveWorkTree(ctPreviousRevisionTree)
 
 		for _, chart := range charts {
 			if err := t.helm.BuildDependencies(computePreviousRevisionPath(chart.Path())); err != nil {

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -59,11 +59,11 @@ func (g fakeGit) ListChangedFilesInDirs(commit string, dirs ...string) ([]string
 	}, nil
 }
 
-func (g fakeGit) AddWorkingTree(path string, ref string) error {
+func (g fakeGit) AddWorkTree(path string, ref string) error {
 	return nil
 }
 
-func (g fakeGit) RemoveWorkingTree(path string) error {
+func (g fakeGit) RemoveWorkTree(path string) error {
 	return nil
 }
 

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -16,8 +16,6 @@ package chart
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"strings"
 	"testing"
 
@@ -31,17 +29,11 @@ import (
 type fakeGit struct{}
 
 func (g fakeGit) FileExistsOnBranch(file string, remote string, branch string) bool {
-	_, err := os.Open(computePreviousRevisionPath(file))
-	fmt.Println(err)
-	return err == nil
+	return true
 }
 
 func (g fakeGit) Show(file string, remote string, branch string) (string, error) {
-	b, err := ioutil.ReadFile(computePreviousRevisionPath(file))
-	if err != nil {
-		return "", err
-	}
-	return string(b), nil
+	return "", nil
 }
 
 func (g fakeGit) MergeBase(commit1 string, commit2 string) (string, error) {

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -51,11 +51,11 @@ func (g fakeGit) ListChangedFilesInDirs(commit string, dirs ...string) ([]string
 	}, nil
 }
 
-func (g fakeGit) AddWorkTree(path string, ref string) error {
+func (g fakeGit) AddWorktree(path string, ref string) error {
 	return nil
 }
 
-func (g fakeGit) RemoveWorkTree(path string) error {
+func (g fakeGit) RemoveWorktree(path string) error {
 	return nil
 }
 

--- a/pkg/tool/git.go
+++ b/pkg/tool/git.go
@@ -38,11 +38,11 @@ func (g Git) FileExistsOnBranch(file string, remote string, branch string) bool 
 	return err == nil
 }
 
-func (g Git) AddWorkTree(path string, ref string) error {
+func (g Git) AddWorktree(path string, ref string) error {
 	return g.exec.RunProcess("git", "worktree", "add", path, ref)
 }
 
-func (g Git) RemoveWorkTree(path string) error {
+func (g Git) RemoveWorktree(path string) error {
 	return g.exec.RunProcess("git", "worktree", "remove", path)
 }
 

--- a/pkg/tool/git.go
+++ b/pkg/tool/git.go
@@ -38,11 +38,11 @@ func (g Git) FileExistsOnBranch(file string, remote string, branch string) bool 
 	return err == nil
 }
 
-func (g Git) AddWorkingTree(path string, ref string) error {
+func (g Git) AddWorkTree(path string, ref string) error {
 	return g.exec.RunProcess("git", "worktree", "add", path, ref)
 }
 
-func (g Git) RemoveWorkingTree(path string) error {
+func (g Git) RemoveWorkTree(path string) error {
 	return g.exec.RunProcess("git", "worktree", "remove", path)
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to helm/chart-testing.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

- 8709dde729f4648fb2f08ce96e73ac4d3d117193: Renaming `*WorkingTree` to `*WorkTree` is more consistent with the underlying git commands.
- 37e686641554982be48f3222d697f983df3205e6: Now that we use `git worktree`, we should document which git versions work with `ct`.
- d0d57443dd0f2f2402c85986e49754b85c249858: There is an edge case where `ct` will create a new worktree and then not clean it up if execution is cancelled. This causes `ct` to fail on the next run because `git worktree add` errors if the worktree path already exists. Creating a temp directory for each run fixes that and also should prevent the accidental overwrite of a user-managed git worktree. We should handle the cleanup of the temp directory as part of #60 in the future.

**Which issue this PR fixes**:

**Special notes for your reviewer**:
