### PR TITLE
Update golang on circleci (#146)Update golang on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
             ./e2e-kind.sh
   build:
     docker:
-      - image: golang:1.11.5-alpine3.9
+      - image: golang:1.12.4-alpine3.9
     working_directory: /go/src/github.com/helm/chart-testing
     steps:
       - setup_remote_docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ARG YAMALE_VERSION=1.8.0
 RUN pip install "yamale==$YAMALE_VERSION"
 
 # Install kubectl
-ARG KUBECTL_VERSION=v1.13.2
+ARG KUBECTL_VERSION=v1.14.1
 RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl" && \
     chmod +x kubectl && \
     mv kubectl /usr/local/bin/


### PR DESCRIPTION
**What this PR does / why we need it**:

update golang image on circleci to build chart-testing using golang 1.12.5
