### PR TITLE
Print events on cleanup

### DIFF
--- a/pkg/tool/kubectl.go
+++ b/pkg/tool/kubectl.go
@@ -185,7 +185,7 @@ func (k Kubectl) GetPods(args ...string) ([]string, error) {
 }
 
 func (k Kubectl) GetEvents(namespace string) error {
-	return k.exec.RunProcess("kubectl", "get", "events", "--namespace", namespace)
+	return k.exec.RunProcess("kubectl", "get", "events", "--output", "wide", "--namespace", namespace)
 }
 
 func (k Kubectl) DescribePod(namespace string, pod string) error {

--- a/pkg/tool/kubectl.go
+++ b/pkg/tool/kubectl.go
@@ -184,6 +184,10 @@ func (k Kubectl) GetPods(args ...string) ([]string, error) {
 	return strings.Fields(pods), nil
 }
 
+func (k Kubectl) GetEvents(namespace string) error {
+	return k.exec.RunProcess("kubectl", "get", "events", "--namespace", namespace)
+}
+
 func (k Kubectl) DescribePod(namespace string, pod string) error {
 	return k.exec.RunProcess("kubectl", "describe", "pod", pod, "--namespace", namespace)
 }


### PR DESCRIPTION
Helps identifying issues when Helm timeout because pods cannot be created due to errors.

Affected PR: https://github.com/helm/charts/pull/13444
