### PR TITLE
allow include subcharts

### DIFF
--- a/ct/cmd/listChanged.go
+++ b/ct/cmd/listChanged.go
@@ -19,10 +19,10 @@ import (
 	"os"
 
 	"github.com/MakeNowJust/heredoc"
-
 	"github.com/helm/chart-testing/pkg/chart"
 	"github.com/helm/chart-testing/pkg/config"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func newListChangedCmd() *cobra.Command {
@@ -38,6 +38,7 @@ func newListChangedCmd() *cobra.Command {
 
 	flags := cmd.Flags()
 	addCommonFlags(flags)
+	addListChangedFlags(flags)
 	return cmd
 }
 
@@ -57,4 +58,8 @@ func listChanged(cmd *cobra.Command, args []string) {
 	for _, dir := range chartDirs {
 		fmt.Println(dir)
 	}
+}
+
+func addListChangedFlags(flags *pflag.FlagSet) {
+	flags.Bool("include-subcharts", false, heredoc.Doc("Whether to also include subcharts. (default: false)"))
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -60,6 +60,7 @@ type Configuration struct {
 	SkipMissingValues     bool     `mapstructure:"skip-missing-values"`
 	Namespace             string   `mapstructure:"namespace"`
 	ReleaseLabel          string   `mapstructure:"release-label"`
+	IsIncludeSubCharts    bool     `mapstructure:"include-subcharts"`
 }
 
 func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*Configuration, error) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -125,22 +125,24 @@ func (l DirectoryLister) ListChildDirs(parentDir string, test func(dir string) b
 
 type ChartUtils struct{}
 
-func (u ChartUtils) LookupChartDir(chartDirs []string, dir string) (string, error) {
+func (u ChartUtils) LookupChartDir(chartDirs []string, dir string, isIncludeSubChart bool) (string, error) {
 	for _, chartDir := range chartDirs {
 		currentDir := dir
+
 		for {
 			chartYaml := path.Join(currentDir, "Chart.yaml")
 			parent := path.Dir(path.Dir(chartYaml))
 
 			// check directory has a Chart.yaml and that it is in a
 			// direct subdirectory of a configured charts directory
-			if FileExists(chartYaml) && (parent == chartDir) {
+			if FileExists(chartYaml) && ((parent == chartDir) || isIncludeSubChart) {
 				return currentDir, nil
 			}
 
 			currentDir = path.Dir(currentDir)
 			relativeDir, _ := filepath.Rel(chartDir, currentDir)
 			joined := path.Join(chartDir, relativeDir)
+
 			if (joined == chartDir) || strings.HasPrefix(relativeDir, "..") {
 				break
 			}


### PR DESCRIPTION
Assuming an umbrella helm chart called `kube-monitoring` with multiple subcharts that looks like this
```
└── kube-monitoring
    ├── charts
    │     ├── prometheus
    │     ├── grafana
...
```

If one applies a change to the `prometheus` chart, the `ct list-changed ...` would only show that the umbrella chart `kube-monitoring` changed but not the subchart.

This PR adds an option to also include the subcharts in the output of `ct list-changed ..` in addition to the umbrella chart:
```
kube-monitoring
kube-monitoring/charts/prometheus
```