### PR TITLE
Only print configuration if --debug flag is present.

### DIFF
--- a/ct/cmd/install.go
+++ b/ct/cmd/install.go
@@ -83,7 +83,7 @@ func addInstallFlags(flags *flag.FlagSet) {
 func install(cmd *cobra.Command, args []string) {
 	fmt.Println("Installing charts...")
 
-	configuration, err := config.LoadConfiguration(cfgFile, cmd, true)
+	configuration, err := config.LoadConfiguration(cfgFile, cmd)
 	if err != nil {
 		fmt.Printf("Error loading configuration: %s\n", err)
 		os.Exit(1)

--- a/ct/cmd/lint.go
+++ b/ct/cmd/lint.go
@@ -75,7 +75,7 @@ func addLintFlags(flags *flag.FlagSet) {
 func lint(cmd *cobra.Command, args []string) {
 	fmt.Println("Linting charts...")
 
-	configuration, err := config.LoadConfiguration(cfgFile, cmd, true)
+	configuration, err := config.LoadConfiguration(cfgFile, cmd)
 	if err != nil {
 		fmt.Printf("Error loading configuration: %s\n", err)
 		os.Exit(1)

--- a/ct/cmd/lintAndInstall.go
+++ b/ct/cmd/lintAndInstall.go
@@ -43,7 +43,7 @@ func newLintAndInstallCmd() *cobra.Command {
 func lintAndInstall(cmd *cobra.Command, args []string) {
 	fmt.Println("Linting and installing charts...")
 
-	configuration, err := config.LoadConfiguration(cfgFile, cmd, true)
+	configuration, err := config.LoadConfiguration(cfgFile, cmd)
 	if err != nil {
 		fmt.Printf("Error loading configuration: %s\n", err)
 		os.Exit(1)

--- a/ct/cmd/listChanged.go
+++ b/ct/cmd/listChanged.go
@@ -42,7 +42,7 @@ func newListChangedCmd() *cobra.Command {
 }
 
 func listChanged(cmd *cobra.Command, args []string) {
-	configuration, err := config.LoadConfiguration(cfgFile, cmd, false)
+	configuration, err := config.LoadConfiguration(cfgFile, cmd)
 	if err != nil {
 		fmt.Printf("Error loading configuration: %s\n", err)
 		os.Exit(1)

--- a/ct/cmd/root.go
+++ b/ct/cmd/root.go
@@ -69,6 +69,9 @@ func addCommonFlags(flags *pflag.FlagSet) {
 	flags.StringSlice("excluded-charts", []string{}, heredoc.Doc(`
 		Charts that should be skipped. May be specified multiple times
 		or separate values with commas`))
+	flags.Bool("debug", false, heredoc.Doc(`
+		Print CLI calls of external tools to stdout (Note: depending on helm-extra-args
+		passed, this may reveal sensitive data)`))
 }
 
 func addCommonLintAndInstallFlags(flags *pflag.FlagSet) {
@@ -89,7 +92,4 @@ func addCommonLintAndInstallFlags(flags *pflag.FlagSet) {
 		specified on a per-repo basis with an equals sign as delimiter
 		(e.g. 'myrepo=--username test --password secret'). May be specified
 		multiple times or separate values with commas`))
-	flags.Bool("debug", false, heredoc.Doc(`
-		Print CLI calls of external tools to stdout (Note: depending on helm-extra-args
-		passed, this may reveal sensitive data)`))
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -62,7 +62,7 @@ type Configuration struct {
 	ReleaseLabel          string   `mapstructure:"release-label"`
 }
 
-func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*Configuration, error) {
+func LoadConfiguration(cfgFile string, cmd *cobra.Command) (*Configuration, error) {
 	v := viper.New()
 
 	cmd.Flags().VisitAll(func(flag *flag.Flag) {
@@ -94,7 +94,7 @@ func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*C
 			return nil, errors.Wrap(err, "Error loading config file")
 		}
 	} else {
-		if printConfig {
+		if v.GetBool("debug") {
 			fmt.Println("Using config file: ", v.ConfigFileUsed())
 		}
 	}
@@ -147,7 +147,7 @@ func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*C
 		cfg.CheckVersionIncrement = false
 	}
 
-	if printConfig {
+	if v.GetBool("debug") {
 		printCfg(cfg)
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -32,7 +32,7 @@ func TestUnmarshalJson(t *testing.T) {
 func loadAndAssertConfigFromFile(t *testing.T, configFile string) {
 	cfg, _ := LoadConfiguration(configFile, &cobra.Command{
 		Use: "install",
-	}, true)
+	})
 
 	require.Equal(t, "origin", cfg.Remote)
 	require.Equal(t, "master", cfg.TargetBranch)


### PR DESCRIPTION
<!--
Thank you for contributing to helm/chart-testing.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
The current behavior prints HelmRepoExtraArgs to stdout. This can possibly include sensitive details (including helm repo logins). This PR hides configuration info behind the --debug flag. 

**Which issue this PR fixes**: None.

**Special notes for your reviewer**:
