### PR TITLE
Exec plugin system

### DIFF
--- a/ct/cmd/install.go
+++ b/ct/cmd/install.go
@@ -90,14 +90,12 @@ func install(cmd *cobra.Command, args []string) {
 	}
 
 	testing := chart.NewTesting(*configuration)
-	results, err := testing.InstallCharts()
+	err = testing.Process()
 	if err != nil {
 		fmt.Printf("Error installing charts: %s\n", err)
 	} else {
 		fmt.Println("All charts installed successfully")
 	}
-
-	testing.PrintResults(results)
 
 	if err != nil {
 		os.Exit(1)

--- a/ct/cmd/lint.go
+++ b/ct/cmd/lint.go
@@ -70,7 +70,7 @@ func addLintFlags(flags *flag.FlagSet) {
 			Enable schema validation of 'Chart.yaml' using Yamale (default: true)`))
 	flags.Bool("validate-yaml", true, heredoc.Doc(`
 			Enable linting of 'Chart.yaml' and values files (default: true)`))
-	flags.StringArray("custom-manifest-processor", nil, heredoc.Doc(`
+	flags.StringSlice("custom-manifest-processor", nil, heredoc.Doc(`
 			Accepts rendered manifest via stdin. (default: [])`))
 }
 

--- a/ct/cmd/lint.go
+++ b/ct/cmd/lint.go
@@ -70,6 +70,8 @@ func addLintFlags(flags *flag.FlagSet) {
 			Enable schema validation of 'Chart.yaml' using Yamale (default: true)`))
 	flags.Bool("validate-yaml", true, heredoc.Doc(`
 			Enable linting of 'Chart.yaml' and values files (default: true)`))
+	flags.StringArray("custom-linter", nil, heredoc.Doc(`
+			Add a custom linter to the processing line. (default: [])`))
 }
 
 func lint(cmd *cobra.Command, args []string) {

--- a/ct/cmd/lint.go
+++ b/ct/cmd/lint.go
@@ -70,8 +70,8 @@ func addLintFlags(flags *flag.FlagSet) {
 			Enable schema validation of 'Chart.yaml' using Yamale (default: true)`))
 	flags.Bool("validate-yaml", true, heredoc.Doc(`
 			Enable linting of 'Chart.yaml' and values files (default: true)`))
-	flags.StringArray("custom-linter", nil, heredoc.Doc(`
-			Add a custom linter to the processing line. (default: [])`))
+	flags.StringArray("custom-manifest-processor", nil, heredoc.Doc(`
+			Accepts rendered manifest via stdin. (default: [])`))
 }
 
 func lint(cmd *cobra.Command, args []string) {
@@ -84,14 +84,12 @@ func lint(cmd *cobra.Command, args []string) {
 	}
 
 	testing := chart.NewTesting(*configuration)
-	results, err := testing.LintCharts()
+	err = testing.Process()
 	if err != nil {
 		fmt.Printf("Error linting charts: %s\n", err)
 	} else {
 		fmt.Println("All charts linted successfully")
 	}
-
-	testing.PrintResults(results)
 
 	if err != nil {
 		os.Exit(1)

--- a/ct/cmd/lintAndInstall.go
+++ b/ct/cmd/lintAndInstall.go
@@ -50,14 +50,12 @@ func lintAndInstall(cmd *cobra.Command, args []string) {
 	}
 
 	testing := chart.NewTesting(*configuration)
-	results, err := testing.LintAndInstallCharts()
+	err = testing.Process()
 	if err != nil {
 		fmt.Printf("Error linting and installing charts: %s\n", err)
 	} else {
 		fmt.Println("All charts linted and installed successfully")
 	}
-
-	testing.PrintResults(results)
 
 	if err != nil {
 		os.Exit(1)

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -233,11 +233,6 @@ type Testing struct {
 	chartProcessors          []ChartProcessor
 }
 
-// TestResult holds test results for a specific chart
-type TestResult struct {
-	Error error // Wrap all of the errors
-}
-
 type ChartProcessor interface {
 	ProcessChart(chart *Chart) error
 }
@@ -300,7 +295,7 @@ func (t *Testing) Process() error {
 	t.PrintResults(charts, results)
 
 	for _, r := range results {
-		if r.Error != nil {
+		if r != nil {
 			return errors.New("At least one chart is a failed")
 		}
 	}
@@ -401,20 +396,20 @@ func (t *Testing) renderCharts() ([]*Chart, error) {
 	return charts, nil
 }
 
-func (t *Testing) processCharts(charts []*Chart) []TestResult {
-	results := make([]TestResult, len(charts))
+func (t *Testing) processCharts(charts []*Chart) []error {
+	results := make([]error, len(charts))
 
 	for _, processor := range t.chartProcessors {
 		for idxChart, chart := range charts {
 			// Don't process any other step if already failed, don't want to
 			// override previous errors
-			if results[idxChart].Error != nil {
+			if results[idxChart] != nil {
 				continue
 			}
 
 			err := processor.ProcessChart(chart)
 			if err != nil {
-				results[idxChart].Error = err
+				results[idxChart] = err
 			}
 
 		}
@@ -424,13 +419,13 @@ func (t *Testing) processCharts(charts []*Chart) []TestResult {
 }
 
 // PrintResults writes test results to stdout.
-func (t *Testing) PrintResults(charts []*Chart, results []TestResult) {
+func (t *Testing) PrintResults(charts []*Chart, results []error) {
 	util.PrintDelimiterLine("-")
 	if results != nil {
 		for idx, result := range results {
 
-			if result.Error != nil {
-				fmt.Printf(" %s %s > %s\n", "✖︎", charts[idx], result.Error)
+			if result != nil {
+				fmt.Printf(" %s %s > %s\n", "✖︎", charts[idx], result)
 			} else {
 				fmt.Printf(" %s %s\n", "✔︎", charts[idx])
 			}

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -235,8 +235,7 @@ type Testing struct {
 
 // TestResult holds test results for a specific chart
 type TestResult struct {
-	PassedAll bool
-	Error     error // Wrap all of the errors
+	Error error // Wrap all of the errors
 }
 
 type ChartProcessor interface {
@@ -410,7 +409,6 @@ func (t *Testing) processCharts(charts []*Chart) []TestResult {
 			err := processor.ProcessChart(chart)
 			if err != nil {
 				results[idxChart].Error = err
-				// or mark what hasn't been processed yet
 			}
 
 		}

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -213,7 +213,7 @@ func TestLintChartMaintainerValidation(t *testing.T) {
 				chart, err := NewChart(testData.chartDir)
 				assert.Nil(t, err)
 				result := ct.processCharts([]*Chart{chart})
-				assert.Equal(t, testData.expected, result[0].Error == nil)
+				assert.Equal(t, testData.expected, result[0] == nil)
 			})
 		}
 	}
@@ -257,7 +257,7 @@ func TestLintChartSchemaValidation(t *testing.T) {
 				chart, err := NewChart(testData.chartDir)
 				assert.Nil(t, err)
 				result := ct.processCharts([]*Chart{chart})
-				assert.Equal(t, testData.expected, result[0].Error == nil)
+				assert.Equal(t, testData.expected, result[0] == nil)
 				fakeMockLinter.AssertNumberOfCalls(t, "Yamale", callsYamale)
 				fakeMockLinter.AssertNumberOfCalls(t, "YamlLint", callsYamlLint)
 			})
@@ -304,7 +304,7 @@ func TestLintYamlValidation(t *testing.T) {
 				chart, err := NewChart(testData.chartDir)
 				assert.Nil(t, err)
 				result := ct.processCharts([]*Chart{chart})
-				assert.Equal(t, testData.expected, result[0].Error == nil)
+				assert.Equal(t, testData.expected, result[0] == nil)
 				fakeMockLinter.AssertNumberOfCalls(t, "Yamale", callsYamale)
 				fakeMockLinter.AssertNumberOfCalls(t, "YamlLint", callsYamlLint)
 			})

--- a/pkg/chart/integration_test.go
+++ b/pkg/chart/integration_test.go
@@ -49,7 +49,7 @@ func TestInstallChart(t *testing.T) {
 		name     string
 		cfg      config.Configuration
 		chartDir string
-		output   TestResult
+		output   error
 	}
 
 	cases := []testCase{
@@ -61,7 +61,7 @@ func TestInstallChart(t *testing.T) {
 				ReleaseLabel: "app.kubernetes.io/instance",
 			},
 			"test_charts/must-pass-upgrade-install",
-			TestResult{mustNewChart("test_charts/must-pass-upgrade-install"), nil},
+			nil,
 		},
 		{
 			"install only in random namespace",
@@ -69,7 +69,7 @@ func TestInstallChart(t *testing.T) {
 				Debug: true,
 			},
 			"test_charts/must-pass-upgrade-install",
-			TestResult{mustNewChart("test_charts/must-pass-upgrade-install"), nil},
+			nil,
 		},
 	}
 
@@ -78,11 +78,11 @@ func TestInstallChart(t *testing.T) {
 			ct := newTestingHelmIntegration(tc.cfg)
 			result := ct.InstallChart(mustNewChart(tc.chartDir))
 
-			if result.Error != tc.output.Error {
-				if result.Error != nil && tc.output.Error != nil {
-					assert.Equal(t, tc.output.Error.Error(), result.Error.Error())
+			if result != tc.output {
+				if result != nil && tc.output != nil {
+					assert.Equal(t, tc.output, result)
 				} else {
-					assert.Equal(t, tc.output.Error, result.Error)
+					assert.Equal(t, tc.output, result)
 				}
 			}
 		})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,28 +39,33 @@ var (
 )
 
 type Configuration struct {
-	Remote                string   `mapstructure:"remote"`
-	TargetBranch          string   `mapstructure:"target-branch"`
-	BuildId               string   `mapstructure:"build-id"`
-	LintConf              string   `mapstructure:"lint-conf"`
-	ChartYamlSchema       string   `mapstructure:"chart-yaml-schema"`
-	ValidateMaintainers   bool     `mapstructure:"validate-maintainers"`
-	ValidateChartSchema   bool     `mapstructure:"validate-chart-schema"`
-	ValidateYaml          bool     `mapstructure:"validate-yaml"`
-	CheckVersionIncrement bool     `mapstructure:"check-version-increment"`
-	ProcessAllCharts      bool     `mapstructure:"all"`
-	Charts                []string `mapstructure:"charts"`
-	ChartRepos            []string `mapstructure:"chart-repos"`
-	ChartDirs             []string `mapstructure:"chart-dirs"`
-	ExcludedCharts        []string `mapstructure:"excluded-charts"`
-	HelmExtraArgs         string   `mapstructure:"helm-extra-args"`
-	HelmRepoExtraArgs     []string `mapstructure:"helm-repo-extra-args"`
-	Debug                 bool     `mapstructure:"debug"`
-	Upgrade               bool     `mapstructure:"upgrade"`
-	SkipMissingValues     bool     `mapstructure:"skip-missing-values"`
-	Namespace             string   `mapstructure:"namespace"`
-	ReleaseLabel          string   `mapstructure:"release-label"`
-	CustomLinters         []string `mapstructure:"custom-linter"`
+	Remote                   string                    `mapstructure:"remote"`
+	TargetBranch             string                    `mapstructure:"target-branch"`
+	BuildId                  string                    `mapstructure:"build-id"`
+	LintConf                 string                    `mapstructure:"lint-conf"`
+	ChartYamlSchema          string                    `mapstructure:"chart-yaml-schema"`
+	ValidateMaintainers      bool                      `mapstructure:"validate-maintainers"`
+	ValidateChartSchema      bool                      `mapstructure:"validate-chart-schema"`
+	ValidateYaml             bool                      `mapstructure:"validate-yaml"`
+	CheckVersionIncrement    bool                      `mapstructure:"check-version-increment"`
+	ProcessAllCharts         bool                      `mapstructure:"all"`
+	Charts                   []string                  `mapstructure:"charts"`
+	ChartRepos               []string                  `mapstructure:"chart-repos"`
+	ChartDirs                []string                  `mapstructure:"chart-dirs"`
+	ExcludedCharts           []string                  `mapstructure:"excluded-charts"`
+	HelmExtraArgs            string                    `mapstructure:"helm-extra-args"`
+	HelmRepoExtraArgs        []string                  `mapstructure:"helm-repo-extra-args"`
+	Debug                    bool                      `mapstructure:"debug"`
+	Upgrade                  bool                      `mapstructure:"upgrade"`
+	SkipMissingValues        bool                      `mapstructure:"skip-missing-values"`
+	Namespace                string                    `mapstructure:"namespace"`
+	ReleaseLabel             string                    `mapstructure:"release-label"`
+	CustomManifestProcessors []CustomManifestProcessor `mapstructure:"custom-manifest-processors"`
+}
+
+type CustomManifestProcessor struct {
+	Command  string `mapstructure:"command"`
+	FailFast bool   `mapstrucutre:"fail-fast"`
 }
 
 func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*Configuration, error) {
@@ -68,7 +73,7 @@ func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*C
 
 	cmd.Flags().VisitAll(func(flag *flag.Flag) {
 		flagName := flag.Name
-		if flagName != "config" && flagName != "help" {
+		if flagName != "config" && flagName != "help" && flagName != "custom-manifest-processor" {
 			if err := v.BindPFlag(flagName, flag); err != nil {
 				// can't really happen
 				panic(fmt.Sprintln(errors.Wrapf(err, "Error binding flag '%s'", flagName)))
@@ -142,6 +147,8 @@ func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*C
 		}
 		cfg.LintConf = cfgFile
 	}
+
+	//TODO: add cli flags
 
 	if len(cfg.Charts) > 0 || cfg.ProcessAllCharts {
 		fmt.Println("Version increment checking disabled.")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -60,6 +60,7 @@ type Configuration struct {
 	SkipMissingValues     bool     `mapstructure:"skip-missing-values"`
 	Namespace             string   `mapstructure:"namespace"`
 	ReleaseLabel          string   `mapstructure:"release-label"`
+	CustomLinters         []string `mapstructure:"custom-linter"`
 }
 
 func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*Configuration, error) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -60,7 +60,7 @@ type Configuration struct {
 	SkipMissingValues        bool     `mapstructure:"skip-missing-values"`
 	Namespace                string   `mapstructure:"namespace"`
 	ReleaseLabel             string   `mapstructure:"release-label"`
-	CustomManifestProcessors []string `mapstructure:"custom-manifest-processors"`
+	CustomManifestProcessors []string `mapstructure:"custom-manifest-processor"`
 }
 
 func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*Configuration, error) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,33 +39,28 @@ var (
 )
 
 type Configuration struct {
-	Remote                   string                    `mapstructure:"remote"`
-	TargetBranch             string                    `mapstructure:"target-branch"`
-	BuildId                  string                    `mapstructure:"build-id"`
-	LintConf                 string                    `mapstructure:"lint-conf"`
-	ChartYamlSchema          string                    `mapstructure:"chart-yaml-schema"`
-	ValidateMaintainers      bool                      `mapstructure:"validate-maintainers"`
-	ValidateChartSchema      bool                      `mapstructure:"validate-chart-schema"`
-	ValidateYaml             bool                      `mapstructure:"validate-yaml"`
-	CheckVersionIncrement    bool                      `mapstructure:"check-version-increment"`
-	ProcessAllCharts         bool                      `mapstructure:"all"`
-	Charts                   []string                  `mapstructure:"charts"`
-	ChartRepos               []string                  `mapstructure:"chart-repos"`
-	ChartDirs                []string                  `mapstructure:"chart-dirs"`
-	ExcludedCharts           []string                  `mapstructure:"excluded-charts"`
-	HelmExtraArgs            string                    `mapstructure:"helm-extra-args"`
-	HelmRepoExtraArgs        []string                  `mapstructure:"helm-repo-extra-args"`
-	Debug                    bool                      `mapstructure:"debug"`
-	Upgrade                  bool                      `mapstructure:"upgrade"`
-	SkipMissingValues        bool                      `mapstructure:"skip-missing-values"`
-	Namespace                string                    `mapstructure:"namespace"`
-	ReleaseLabel             string                    `mapstructure:"release-label"`
-	CustomManifestProcessors []CustomManifestProcessor `mapstructure:"custom-manifest-processors"`
-}
-
-type CustomManifestProcessor struct {
-	Command  string `mapstructure:"command"`
-	FailFast bool   `mapstrucutre:"fail-fast"`
+	Remote                   string   `mapstructure:"remote"`
+	TargetBranch             string   `mapstructure:"target-branch"`
+	BuildId                  string   `mapstructure:"build-id"`
+	LintConf                 string   `mapstructure:"lint-conf"`
+	ChartYamlSchema          string   `mapstructure:"chart-yaml-schema"`
+	ValidateMaintainers      bool     `mapstructure:"validate-maintainers"`
+	ValidateChartSchema      bool     `mapstructure:"validate-chart-schema"`
+	ValidateYaml             bool     `mapstructure:"validate-yaml"`
+	CheckVersionIncrement    bool     `mapstructure:"check-version-increment"`
+	ProcessAllCharts         bool     `mapstructure:"all"`
+	Charts                   []string `mapstructure:"charts"`
+	ChartRepos               []string `mapstructure:"chart-repos"`
+	ChartDirs                []string `mapstructure:"chart-dirs"`
+	ExcludedCharts           []string `mapstructure:"excluded-charts"`
+	HelmExtraArgs            string   `mapstructure:"helm-extra-args"`
+	HelmRepoExtraArgs        []string `mapstructure:"helm-repo-extra-args"`
+	Debug                    bool     `mapstructure:"debug"`
+	Upgrade                  bool     `mapstructure:"upgrade"`
+	SkipMissingValues        bool     `mapstructure:"skip-missing-values"`
+	Namespace                string   `mapstructure:"namespace"`
+	ReleaseLabel             string   `mapstructure:"release-label"`
+	CustomManifestProcessors []string `mapstructure:"custom-manifest-processors"`
 }
 
 func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*Configuration, error) {
@@ -73,7 +68,7 @@ func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*C
 
 	cmd.Flags().VisitAll(func(flag *flag.Flag) {
 		flagName := flag.Name
-		if flagName != "config" && flagName != "help" && flagName != "custom-manifest-processor" {
+		if flagName != "config" && flagName != "help" {
 			if err := v.BindPFlag(flagName, flag); err != nil {
 				// can't really happen
 				panic(fmt.Sprintln(errors.Wrapf(err, "Error binding flag '%s'", flagName)))
@@ -147,8 +142,6 @@ func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*C
 		}
 		cfg.LintConf = cfgFile
 	}
-
-	//TODO: add cli flags
 
 	if len(cfg.Charts) > 0 || cfg.ProcessAllCharts {
 		fmt.Println("Version increment checking disabled.")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -53,6 +53,5 @@ func loadAndAssertConfigFromFile(t *testing.T, configFile string) {
 	require.Equal(t, true, cfg.SkipMissingValues)
 	require.Equal(t, "default", cfg.Namespace)
 	require.Equal(t, "release", cfg.ReleaseLabel)
-	require.Equal(t, "test", cfg.CustomManifestProcessors[0].Command)
-	require.Equal(t, false, cfg.CustomManifestProcessors[0].FailFast)
+	require.Equal(t, []string{"test"}, cfg.CustomManifestProcessors)
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -53,4 +53,6 @@ func loadAndAssertConfigFromFile(t *testing.T, configFile string) {
 	require.Equal(t, true, cfg.SkipMissingValues)
 	require.Equal(t, "default", cfg.Namespace)
 	require.Equal(t, "release", cfg.ReleaseLabel)
+	require.Equal(t, "test", cfg.CustomManifestProcessors[0].Command)
+	require.Equal(t, false, cfg.CustomManifestProcessors[0].FailFast)
 }

--- a/pkg/config/test_config.json
+++ b/pkg/config/test_config.json
@@ -23,6 +23,12 @@
     "excluded-charts": [
         "common"
     ],
+    "custom-manifest-processors": [
+        {
+            "command": "test",
+            "fail-fast": false
+        }
+    ],
     "helm-extra-args": "--timeout 300",
     "upgrade": true,
     "skip-missing-values": true,

--- a/pkg/config/test_config.json
+++ b/pkg/config/test_config.json
@@ -23,7 +23,7 @@
     "excluded-charts": [
         "common"
     ],
-    "custom-manifest-processors": [
+    "custom-manifest-processor": [
         "test"
     ],
     "helm-extra-args": "--timeout 300",

--- a/pkg/config/test_config.json
+++ b/pkg/config/test_config.json
@@ -24,10 +24,7 @@
         "common"
     ],
     "custom-manifest-processors": [
-        {
-            "command": "test",
-            "fail-fast": false
-        }
+        "test"
     ],
     "helm-extra-args": "--timeout 300",
     "upgrade": true,

--- a/pkg/config/test_config.yaml
+++ b/pkg/config/test_config.yaml
@@ -18,7 +18,7 @@ chart-dirs:
   - incubator
 excluded-charts:
   - common
-custom-manifest-processors:
+custom-manifest-processor:
   - "test"
 helm-extra-args: --timeout 300
 upgrade: true

--- a/pkg/config/test_config.yaml
+++ b/pkg/config/test_config.yaml
@@ -19,8 +19,7 @@ chart-dirs:
 excluded-charts:
   - common
 custom-manifest-processors:
-  - command: "test"
-    fail-fast: false
+  - "test"
 helm-extra-args: --timeout 300
 upgrade: true
 skip-missing-values: true

--- a/pkg/config/test_config.yaml
+++ b/pkg/config/test_config.yaml
@@ -18,6 +18,9 @@ chart-dirs:
   - incubator
 excluded-charts:
   - common
+custom-manifest-processors:
+  - command: "test"
+    fail-fast: false
 helm-extra-args: --timeout 300
 upgrade: true
 skip-missing-values: true

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -17,12 +17,13 @@ package exec
 import (
 	"bufio"
 	"fmt"
-	"github.com/helm/chart-testing/pkg/util"
-	"github.com/pkg/errors"
 	"io"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/helm/chart-testing/pkg/util"
+	"github.com/pkg/errors"
 )
 
 type ProcessExecutor struct {

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -97,35 +97,12 @@ func (p ProcessExecutor) RunProcessWithPipedInput(inputString string, executable
 		return err
 	}
 
-	outReader, err := cmd.StdoutPipe()
-	if err != nil {
-		return errors.Wrap(err, "Error getting StdoutPipe for command")
-	}
-
-	errReader, err := cmd.StderrPipe()
-	if err != nil {
-		return errors.Wrap(err, "Error getting StderrPipe for command")
-	}
-
-	scanner := bufio.NewScanner(io.MultiReader(outReader, errReader))
-	go func() {
-		for scanner.Scan() {
-			fmt.Println(scanner.Text())
-		}
-	}()
-
 	cmd.Stdin = strings.NewReader(inputString)
-	err = cmd.Start()
-	if err != nil {
-		return errors.Wrap(err, "Error running process")
-	}
 
-	err = cmd.Wait()
-	if err != nil {
-		return errors.Wrap(err, "Error waiting for process")
-	}
+	bytes, err := cmd.CombinedOutput()
+	fmt.Println(string(bytes))
 
-	return nil
+	return err
 }
 
 func (p ProcessExecutor) CreateProcess(executable string, execArgs ...interface{}) (*exec.Cmd, error) {

--- a/pkg/tool/helm.go
+++ b/pkg/tool/helm.go
@@ -86,3 +86,12 @@ func (h Helm) DeleteRelease(release string) {
 		fmt.Println("Error deleting Helm release:", err)
 	}
 }
+
+func (h Helm) RenderTemplate(chart string, valuesFile string) (string, error) {
+	var values []string
+	if valuesFile != "" {
+		values = []string{"--values", valuesFile}
+	}
+
+	return h.exec.RunProcessAndCaptureOutput("helm", "template", chart, values)
+}

--- a/pkg/tool/linter.go
+++ b/pkg/tool/linter.go
@@ -33,3 +33,7 @@ func (l Linter) YamlLint(yamlFile string, configFile string) error {
 func (l Linter) Yamale(yamlFile string, schemaFile string) error {
 	return l.exec.RunProcess("yamale", "--schema", schemaFile, yamlFile)
 }
+
+func (l Linter) CustomLint(exec string, args ...string) error {
+	return l.exec.RunProcess(exec, args)
+}

--- a/pkg/tool/linter.go
+++ b/pkg/tool/linter.go
@@ -33,7 +33,3 @@ func (l Linter) YamlLint(yamlFile string, configFile string) error {
 func (l Linter) Yamale(yamlFile string, schemaFile string) error {
 	return l.exec.RunProcess("yamale", "--schema", schemaFile, yamlFile)
 }
-
-func (l Linter) CustomLint(exec string, args ...string) error {
-	return l.exec.RunProcess(exec, args)
-}


### PR DESCRIPTION

**What this PR does / why we need it**:
This PR adds an exec plugin system as described in the linked issue. These plugins can be defined as a flag/config file/env variable and support input via stdin. 

Included in this PR is a refactor of the design of the processing of charts to be consistent with the system described in the issue. This new design should make it easier to add new features to the linting process in the future and makes it easier to add more processors in the future. Behavior is the same as the previous implementation and validated.

One issue is that commands defined via CLI cannot contain a comma(`,`) because of the processing done by Cobra. These commands can be defined in the config file

**Which issue this PR fixes**: 
Fixes https://github.com/helm/chart-testing/issues/163