### PR TITLE
Always use strict helm linting.

### DIFF
--- a/pkg/tool/helm.go
+++ b/pkg/tool/helm.go
@@ -50,7 +50,7 @@ func (h Helm) LintWithValues(chart string, valuesFile string) error {
 		values = []string{"--values", valuesFile}
 	}
 
-	return h.exec.RunProcess("helm", "lint", chart, values)
+	return h.exec.RunProcess("helm", "lint", "--strict", chart, values)
 }
 
 func (h Helm) InstallWithValues(chart string, valuesFile string, namespace string, release string) error {


### PR DESCRIPTION
**What this PR does / why we need it**: Strict helm linting does a more thorough validation of Chart configuration

**Which issue this PR fixes** : fixes #166  
