### PR TITLE
Limit release and namespace name length.

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -28,6 +28,7 @@ import (
 )
 
 const maxNameLength = 63
+const maxReleaseNameLength = 12
 
 // Git is the Interface that wraps Git operations.
 //
@@ -196,6 +197,8 @@ func (c *Chart) CreateInstallParams(buildID string) (release string, namespace s
 		yaml := c.Yaml()
 		release = yaml.Name
 	}
+
+	release = util.SanitizeReleaseName(release, maxReleaseNameLength)
 	namespace = release
 	if buildID != "" {
 		namespace = fmt.Sprintf("%s-%s", namespace, buildID)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -228,6 +228,16 @@ func SanitizeName(s string, maxLength int) string {
 	return reg.ReplaceAllString(result, "")
 }
 
+func SanitizeReleaseName(s string, maxLength int) string {
+	reg := regexp.MustCompile("^[^a-zA-Z0-9]+")
+
+	result := s
+	if len(s) > maxLength {
+		result = s[:maxLength]
+	}
+	return reg.ReplaceAllString(result, "")
+}
+
 func GetRandomPort() (int, error) {
 	listener, err := net.Listen("tcp", ":0")
 	defer listener.Close()

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -91,6 +91,28 @@ func TestSanitizeName(t *testing.T) {
 	}
 }
 
+func TestSanitizeReleaseName(t *testing.T) {
+	var testDataSlice = []struct {
+		input     string
+		maxLength int
+		expected  string
+	}{
+		{"short", 8, "short"},
+		{"length-8", len("length-8"), "length-8"},
+		{"way-longer-than-max-length", 8, "way-long"},
+		{"12345678", len("12345678") + 1, "12345678"},
+		{"123456789", len("123456789") - 1, "12345678"},
+	}
+
+	for index, testData := range testDataSlice {
+		t.Run(string(index), func(t *testing.T) {
+			actual := SanitizeReleaseName(testData.input, testData.maxLength)
+			fmt.Printf("actual: %s,%d, input: %s,%d\n", actual, len(actual), testData.input, testData.maxLength)
+			assert.Equal(t, testData.expected, actual)
+		})
+	}
+}
+
 func TestBreakingChangeAllowed(t *testing.T) {
 	var testDataSlice = []struct {
 		left     string


### PR DESCRIPTION
<!--
Thank you for contributing to helm/chart-testing.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Long names are problematic, especially with operators which tend to add additional suffixes.
Also they are not required since pods/namespaces are created only for tests.

**Which issue this PR fixes** 
fixes #175 

**Special notes for your reviewer**:
