### PR TITLE
Prepare release v2.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Run the script specifying the version for the new release.
 ./tag.sh --tag <release_version>
 ```
 
-Versions must start with a lower-case `v`, e. g. `v2.3.3`.
+Versions must start with a lower-case `v`, e. g. `v2.4.0`.
 
 
 ## Supported versions

--- a/examples/docker-for-mac/my_test.sh
+++ b/examples/docker-for-mac/my_test.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly IMAGE_TAG=v2.3.3
+readonly IMAGE_TAG=v2.4.0
 readonly IMAGE_REPOSITORY="quay.io/helmpack/chart-testing"
 
 main() {

--- a/examples/gke/Dockerfile
+++ b/examples/gke/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/helmpack/chart-testing:v2.3.3
+FROM quay.io/helmpack/chart-testing:v2.4.0
 
 ENV PATH /google-cloud-sdk/bin:$PATH
 ARG CLOUD_SDK_VERSION=221.0.0

--- a/examples/kind/.circleci/config.yml
+++ b/examples/kind/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
 
   lint-charts:
     docker:
-      - image: quay.io/helmpack/chart-testing:v2.3.3
+      - image: quay.io/helmpack/chart-testing:v2.4.0
     steps:
       - checkout
       - run:

--- a/examples/kind/test/e2e-kind.sh
+++ b/examples/kind/test/e2e-kind.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly CT_VERSION=v2.3.3
+readonly CT_VERSION=v2.4.0
 readonly KIND_VERSION=v0.5.1
 readonly CLUSTER_NAME=chart-testing
 readonly K8S_VERSION=v1.15.3


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates versions in example docs in order to prepare a new release that would contain changes since `v2.3.3`

**Which issue this PR fixes**
There is no formal issue number, but it would resolve an issue reported in [slack](https://kubernetes.slack.com/archives/CHK6WB5R8/p1571917162009500), 
```
vas 07:39
Hey, is there a plan to release a new chart-testing image with a newer version of Helm that contains this fix: https://github.com/helm/helm/pull/5112?
The latest image is 3.3.2, which has Helm 2.13.1, and it appears that this does not have the fix in it.
```
EDIT: Fixes #179 

**Special notes for your reviewer**:
Apologies if this is jumping the gun on a release, I am not too familiar with your standard process.