### PR TITLE
Bump helm to v2.16.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$KUBECTL
     mv kubectl /usr/local/bin/
 
 # Install Helm
-ARG HELM_VERSION=v2.15.2
+ARG HELM_VERSION=v2.16.0
 RUN curl -LO "https://kubernetes-helm.storage.googleapis.com/helm-$HELM_VERSION-linux-amd64.tar.gz" && \
     mkdir -p "/usr/local/helm-$HELM_VERSION" && \
     tar -xzf "helm-$HELM_VERSION-linux-amd64.tar.gz" -C "/usr/local/helm-$HELM_VERSION" && \


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps the helm version to `v2.16.0`

**Special notes for your reviewer**:
I saw that the `v3.0.0` pr is in progress, not sure if you were planning on continuing to support 2.x.x after that is merged.