### PR TITLE
Update source install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ available tags [here](https://quay.io/repository/helmpack/chart-testing?tab=tags
 To install from head with [Go](https://golang.org) 1.13 or higher:
 
 ```cli
-go get github.com/helm/chart-testing/v3/ct
+go get github.com/helm/chart-testing/ct
 ```
 
 This will put `ct` in `$(go env GOPATH)/bin`. You may need to add that directory to your `$PATH` as shown [here](https://golang.org/doc/code.html#GOPATH) if you encounter the error `ct: command not found` after installation.


### PR DESCRIPTION
**What this PR does / why we need it**:
Change "github.com/helm/chart-testing/v3/ct" to "github.com/helm/chart-testing/ct"  in https://github.com/helm/chart-testing#from-source

The directory was moved (presumably as part of the Helm 3 release) and attempting to get it using the existing location produces a "not found" error, e.g.

```
$ go get -v -u github.com/helm/chart-testing/v3/ct           
github.com/helm/chart-testing (download)                             
package github.com/helm/chart-testing/v3/ct: cannot find package "github.com/helm/chart-testing/v3/ct" in any of:
	/usr/lib/go/src/github.com/helm/chart-testing/v3/ct (from $GOROOT)
	/home/user/go/src/github.com/helm/chart-testing/v3/ct (from $GOPATH)
```
