### PR TITLE
Enable strict helm linting

### DIFF
--- a/ct/cmd/lint.go
+++ b/ct/cmd/lint.go
@@ -68,6 +68,8 @@ func addLintFlags(flags *flag.FlagSet) {
 			Enable schema validation of 'Chart.yaml' using Yamale (default: true)`))
 	flags.Bool("validate-yaml", true, heredoc.Doc(`
 			Enable linting of 'Chart.yaml' and values files (default: true)`))
+	flags.Bool("strict-lint", false, heredoc.Doc(`
+			Enable strict chart linting (default: false)`))
 }
 
 func lint(cmd *cobra.Command, args []string) error {

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -245,10 +245,14 @@ type TestResult struct {
 func NewTesting(config config.Configuration) (Testing, error) {
 	procExec := exec.NewProcessExecutor(config.Debug)
 	extraArgs := strings.Fields(config.HelmExtraArgs)
+	lintArgs := []string{}
+	if config.StrictLint {
+		lintArgs = append(lintArgs, "--strict")
+	}
 
 	testing := Testing{
 		config:           config,
-		helm:             tool.NewHelm(procExec, extraArgs),
+		helm:             tool.NewHelm(procExec, extraArgs, lintArgs),
 		git:              tool.NewGit(procExec),
 		kubectl:          tool.NewKubectl(procExec),
 		linter:           tool.NewLinter(procExec),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -47,6 +47,7 @@ type Configuration struct {
 	ValidateMaintainers   bool     `mapstructure:"validate-maintainers"`
 	ValidateChartSchema   bool     `mapstructure:"validate-chart-schema"`
 	ValidateYaml          bool     `mapstructure:"validate-yaml"`
+	StrictLint            bool     `mapstructure:"strict-lint"`
 	CheckVersionIncrement bool     `mapstructure:"check-version-increment"`
 	ProcessAllCharts      bool     `mapstructure:"all"`
 	Charts                []string `mapstructure:"charts"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -42,6 +42,7 @@ func loadAndAssertConfigFromFile(t *testing.T, configFile string) {
 	require.Equal(t, true, cfg.ValidateMaintainers)
 	require.Equal(t, true, cfg.ValidateChartSchema)
 	require.Equal(t, true, cfg.ValidateYaml)
+	require.Equal(t, true, cfg.StrictLint)
 	require.Equal(t, true, cfg.CheckVersionIncrement)
 	require.Equal(t, false, cfg.ProcessAllCharts)
 	require.Equal(t, []string{"incubator=https://incubator"}, cfg.ChartRepos)

--- a/pkg/config/test_config.json
+++ b/pkg/config/test_config.json
@@ -8,6 +8,7 @@
     "validate-maintainers": true,
     "validate-chart-schema": true,
     "validate-yaml": true,
+    "strict-lint": true,
     "check-version-increment": true,
     "all": false,
     "chart-repos": [

--- a/pkg/config/test_config.yaml
+++ b/pkg/config/test_config.yaml
@@ -7,6 +7,7 @@ github-instance: https://github.com
 validate-maintainers: true
 validate-chart-schema: true
 validate-yaml: true
+strict-lint: true
 check-version-increment: true
 all: false
 chart-repos:

--- a/pkg/tool/helm.go
+++ b/pkg/tool/helm.go
@@ -23,12 +23,14 @@ import (
 type Helm struct {
 	exec      exec.ProcessExecutor
 	extraArgs []string
+	lintArgs  []string
 }
 
-func NewHelm(exec exec.ProcessExecutor, extraArgs []string) Helm {
+func NewHelm(exec exec.ProcessExecutor, extraArgs []string, lintArgs []string) Helm {
 	return Helm{
 		exec:      exec,
 		extraArgs: extraArgs,
+		lintArgs:  lintArgs,
 	}
 }
 
@@ -46,7 +48,7 @@ func (h Helm) LintWithValues(chart string, valuesFile string) error {
 		values = []string{"--values", valuesFile}
 	}
 
-	return h.exec.RunProcess("helm", "lint", chart, values)
+	return h.exec.RunProcess("helm", "lint", h.lintArgs, chart, values)
 }
 
 func (h Helm) InstallWithValues(chart string, valuesFile string, namespace string, release string) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

Creates a flag to enable `helm lint` to run with `--strict` mode. 

**Which issue this PR fixes** : 
closes #166 

**Special notes for your reviewer**:

Actual lint run test isn't written yet.  I'd like confirmation the approach is good first.  

I debated whether to have the `ct` flag be set up to enable arbitrary lint args rather than specifically `--strict`.  My thought was that an explicit true/false choice would encourage users to consider using strict mode, but I'm open to changing the flag to be more generic like `extraArgs`.