### PR TITLE
examples/kind: Add timeout unit in config

### DIFF
--- a/examples/kind/test/ct.yaml
+++ b/examples/kind/test/ct.yaml
@@ -1,1 +1,1 @@
-helm-extra-args: --timeout 800
+helm-extra-args: --timeout 800s


### PR DESCRIPTION
helm3 requires the timeout value to have a unit.
Without this, the test results in the following error:

```
Error: invalid argument "800" for "--timeout" flag: time: missing unit in duration 800
```

<!--
Thank you for contributing to helm/chart-testing.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
This PR updates ct config in the kind example. It is needed to pass correct timeout argument to helm3.

<!--
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
-->