### PR TITLE
allow to skip namespace creation

### DIFF
--- a/ct/cmd/install.go
+++ b/ct/cmd/install.go
@@ -70,6 +70,9 @@ func addInstallFlags(flags *flag.FlagSet) {
 		When --upgrade has been passed, this flag will skip testing CI values files from the
 		previous chart revision if they have been deleted or renamed at the current chart
 		revision`))
+	flags.Bool("skip-namespace-creation", false, heredoc.Doc(`
+		Skips namespace creation and deletion. Can only be used in conjuction with --namespace
+		The specified namespace must already exist.`))
 	flags.String("namespace", "", heredoc.Doc(`
 		Namespace to install the release(s) into. If not specified, each release will be
 		installed in its own randomly generated namespace`))

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -541,8 +541,10 @@ func (t *Testing) doInstall(chart *Chart) error {
 			namespace, release, releaseSelector, cleanup := t.generateInstallConfig(chart)
 			defer cleanup()
 
-			if err := t.kubectl.CreateNamespace(namespace); err != nil {
-				return err
+			if t.config.SkipNamespaceCreation == false {
+				if err := t.kubectl.CreateNamespace(namespace); err != nil {
+					return err
+				}
 			}
 			if err := t.helm.InstallWithValues(chart.Path(), valuesFile, namespace, release); err != nil {
 				return err
@@ -637,7 +639,9 @@ func (t *Testing) generateInstallConfig(chart *Chart) (namespace, release, relea
 		cleanup = func() {
 			t.PrintEventsPodDetailsAndLogs(namespace, releaseSelector)
 			t.helm.DeleteRelease(namespace, release)
-			t.kubectl.DeleteNamespace(namespace)
+			if t.config.SkipNamespaceCreation == false {
+				t.kubectl.DeleteNamespace(namespace)
+			}
 		}
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,6 +58,7 @@ type Configuration struct {
 	Debug                 bool     `mapstructure:"debug"`
 	Upgrade               bool     `mapstructure:"upgrade"`
 	SkipMissingValues     bool     `mapstructure:"skip-missing-values"`
+	SkipNamespaceCreation bool     `mapstructure:"skip-namespace-creation"`
 	Namespace             string   `mapstructure:"namespace"`
 	ReleaseLabel          string   `mapstructure:"release-label"`
 }
@@ -113,6 +114,10 @@ func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*C
 
 	if cfg.Namespace != "" && cfg.ReleaseLabel == "" {
 		return nil, errors.New("specifying '--namespace' without '--release-label' is not allowed")
+	}
+
+	if cfg.SkipNamespaceCreation == true && cfg.Namespace == "" {
+		return nil, errors.New("specifying '--skip-namespace-creation' without '--namespace' is not allowed")
 	}
 
 	// Disable upgrade (this does some expensive dependency building on previous revisions)


### PR DESCRIPTION
<!--
Thank you for contributing to helm/chart-testing.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

In some environments it's not reasonable to allow creation and deletion of namespaces. This flag allows to use chart testing with already existing namespaces.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

It's missing tests. Just want to get feedback if this would be a useful addition.