### PR TITLE
Don't create provided namespace

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -16,10 +16,11 @@ package chart
 
 import (
 	"fmt"
-	"github.com/Masterminds/semver"
 	"io/ioutil"
 	"path/filepath"
 	"strings"
+
+	"github.com/Masterminds/semver"
 
 	"github.com/helm/chart-testing/v3/pkg/config"
 	"github.com/helm/chart-testing/v3/pkg/exec"
@@ -541,8 +542,10 @@ func (t *Testing) doInstall(chart *Chart) error {
 			namespace, release, releaseSelector, cleanup := t.generateInstallConfig(chart)
 			defer cleanup()
 
-			if err := t.kubectl.CreateNamespace(namespace); err != nil {
-				return err
+			if t.config.Namespace == "" {
+				if err := t.kubectl.CreateNamespace(namespace); err != nil {
+					return err
+				}
 			}
 			if err := t.helm.InstallWithValues(chart.Path(), valuesFile, namespace, release); err != nil {
 				return err
@@ -579,8 +582,10 @@ func (t *Testing) doUpgrade(oldChart, newChart *Chart, oldChartMustPass bool) er
 			namespace, release, releaseSelector, cleanup := t.generateInstallConfig(oldChart)
 			defer cleanup()
 
-			if err := t.kubectl.CreateNamespace(namespace); err != nil {
-				return err
+			if t.config.Namespace == "" {
+				if err := t.kubectl.CreateNamespace(namespace); err != nil {
+					return err
+				}
 			}
 			// Install previous version of chart. If installation fails, ignore this release.
 			if err := t.helm.InstallWithValues(oldChart.Path(), valuesFile, namespace, release); err != nil {

--- a/pkg/chart/integration_test.go
+++ b/pkg/chart/integration_test.go
@@ -76,6 +76,11 @@ func TestInstallChart(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ct := newTestingHelmIntegration(tc.cfg)
+			namespace := tc.cfg.Namespace
+			if namespace != "" {
+				ct.kubectl.CreateNamespace(namespace)
+				defer ct.kubectl.DeleteNamespace(namespace)
+			}
 			result := ct.InstallChart(mustNewChart(tc.chartDir))
 
 			if result.Error != tc.output.Error {

--- a/pkg/chart/test_charts/mutating-deployment-selector/templates/deployment.yaml
+++ b/pkg/chart/test_charts/mutating-deployment-selector/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "nginx.fullname" . }}

--- a/pkg/chart/test_charts/mutating-sfs-volumeclaim/templates/service.yaml
+++ b/pkg/chart/test_charts/mutating-sfs-volumeclaim/templates/service.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   type: {{ .Values.service.type }}
+  clusterIP: None
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/pkg/chart/test_charts/mutating-sfs-volumeclaim/templates/statefulset.yaml
+++ b/pkg/chart/test_charts/mutating-sfs-volumeclaim/templates/statefulset.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  serviceName: {{ include "nginx.fullname" . }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "nginx.name" . }}


### PR DESCRIPTION
Adding support for Helm 3 introduced creating namespaces
because Helm does not do this automatically anymore.
However, a regression was introduced that always creates
namespaces, even if a dedicated namespace is provided via
CLI flag.

Signed-off-by: Reinhard Naegele <unguiculus@gmail.com>
