### PR TITLE
Update Helm to v3.1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
             chmod +x ./kubectl
             sudo mv ./kubectl /usr/local/bin/kubectl
 
-            helm_version=v3.0.3
+            helm_version=v3.1.1
             curl -sSLO "https://get.helm.sh/helm-$helm_version-linux-amd64.tar.gz"
             sudo mkdir -p "/usr/local/helm-$helm_version"
             sudo tar -xzf "helm-$helm_version-linux-amd64.tar.gz" -C "/usr/local/helm-$helm_version"

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$KUBECTL
     mv kubectl /usr/local/bin/
 
 # Install Helm
-ARG HELM_VERSION=v3.0.1
+ARG HELM_VERSION=v3.1.0
 RUN curl -LO "https://get.helm.sh/helm-$HELM_VERSION-linux-amd64.tar.gz" && \
     mkdir -p "/usr/local/helm-$HELM_VERSION" && \
     tar -xzf "helm-$HELM_VERSION-linux-amd64.tar.gz" -C "/usr/local/helm-$HELM_VERSION" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$KUBECTL
     mv kubectl /usr/local/bin/
 
 # Install Helm
-ARG HELM_VERSION=v3.1.0
+ARG HELM_VERSION=v3.1.1
 RUN curl -LO "https://get.helm.sh/helm-$HELM_VERSION-linux-amd64.tar.gz" && \
     mkdir -p "/usr/local/helm-$HELM_VERSION" && \
     tar -xzf "helm-$HELM_VERSION-linux-amd64.tar.gz" -C "/usr/local/helm-$HELM_VERSION" && \


### PR DESCRIPTION
Helm v3.0.1 lint on my library chart produces nested file error which is fixed in v3.1.0.