### PR TITLE
show results during lint error and do not show usage

### DIFF
--- a/ct/cmd/lint.go
+++ b/ct/cmd/lint.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/MakeNowJust/heredoc"
 	"github.com/helm/chart-testing/v3/pkg/chart"
 	"github.com/helm/chart-testing/v3/pkg/config"
@@ -71,6 +72,8 @@ func addLintFlags(flags *flag.FlagSet) {
 }
 
 func lint(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+
 	fmt.Println("Linting charts...")
 
 	configuration, err := config.LoadConfiguration(cfgFile, cmd, true)
@@ -84,6 +87,7 @@ func lint(cmd *cobra.Command, args []string) error {
 	}
 	results, err := testing.LintCharts()
 	if err != nil {
+		testing.PrintResults(results)
 		return fmt.Errorf("Error linting charts: %s", err)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When linting fails, a summary is not printed and an (unhelpful) usage message for the CLI is printed.
 
`master`:
```sh
etc $ find weird-chart -type f -ls -exec cat {} \;
12169175        8 -rw-r--r--    1 steved           staff                 120 Mar  9 19:09 weird-chart/Chart.yaml
apiVersion: v2
name: weird-chart
version: 1.0.0
home: helm/chart-testing
description: My Weird Chart!
appVersion: 0.0.1
12170329        8 -rw-r--r--    1 steved           staff                  22 Mar  9 19:08 weird-chart/templates/test.yaml
this: {{ will fail }}
12170348        0 -rw-r--r--    1 steved           staff                   0 Mar  9 19:08 weird-chart/values.yaml
etc $ go run ../ct/ lint --chart-dirs . --charts weird-chart
Linting charts...
Version increment checking disabled.
------------------------------------------------------------------------------------------------------------------------
 Configuration
------------------------------------------------------------------------------------------------------------------------
Remote: origin
TargetBranch: master
BuildId:
LintConf: lintconf.yaml
ChartYamlSchema: chart_schema.yaml
ValidateMaintainers: true
ValidateChartSchema: true
ValidateYaml: true
CheckVersionIncrement: false
ProcessAllCharts: false
Charts: [weird-chart]
ChartRepos: []
ChartDirs: [.]
ExcludedCharts: []
HelmExtraArgs:
HelmRepoExtraArgs: []
Debug: false
Upgrade: false
SkipMissingValues: false
Namespace:
ReleaseLabel:
------------------------------------------------------------------------------------------------------------------------

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 weird-chart => (version: "1.0.0", path: "weird-chart")
------------------------------------------------------------------------------------------------------------------------

Linting chart 'weird-chart => (version: "1.0.0", path: "weird-chart")'
Validating /Users/steved/src/chart-testing/etc/weird-chart/Chart.yaml...
Validation success! 👍
Validating maintainers...
Error: Error linting charts: Error processing charts
Usage:
  ct lint [flags]

Flags:
      --all                            Process all charts except those explicitly excluded.
                                       Disables changed charts detection and version increment checking
      --chart-dirs strings             Directories containing Helm charts. May be specified multiple times
                                       or separate values with commas (default [charts])
      --chart-repos strings            Additional chart repositories for dependency resolutions.
                                       Repositories should be formatted as 'name=url' (ex: local=http://127.0.0.1:8879/charts).
                                       May be specified multiple times or separate values with commas
      --chart-yaml-schema string       The schema for chart.yml validation. If not specified, 'chart_schema.yaml'
                                       is searched in the current directory, '$HOME/.ct', and '/etc/ct', in
                                       that order.
      --charts strings                 Specific charts to test. Disables changed charts detection and
                                       version increment checking. May be specified multiple times
                                       or separate values with commas
      --check-version-increment        Activates a check for chart version increments (default: true) (default true)
      --config string                  Config file
      --debug                          Print CLI calls of external tools to stdout (Note: depending on helm-extra-args
                                       passed, this may reveal sensitive data)
      --excluded-charts strings        Charts that should be skipped. May be specified multiple times
                                       or separate values with commas
      --helm-repo-extra-args strings   Additional arguments for the 'helm repo add' command to be
                                       specified on a per-repo basis with an equals sign as delimiter
                                       (e.g. 'myrepo=--username test --password secret'). May be specified
                                       multiple times or separate values with commas
  -h, --help                           help for lint
      --lint-conf string               The config file for YAML linting. If not specified, 'lintconf.yaml'
                                       is searched in the current directory, '$HOME/.ct', and '/etc/ct', in
                                       that order
      --remote string                  The name of the Git remote used to identify changed charts (default "origin")
      --target-branch string           The name of the target branch used to identify changed charts (default "master")
      --validate-chart-schema          Enable schema validation of 'Chart.yaml' using Yamale (default: true) (default true)
      --validate-maintainers           Enable validation of maintainer account names in chart.yml (default: true).
                                       Works for GitHub, GitLab, and Bitbucket (default true)
      --validate-yaml                  Enable linting of 'Chart.yaml' and values files (default: true) (default true)

Error linting charts: Error processing charts
exit status 1
```

this branch:
```sh
$ go run ../ct/ lint --chart-dirs . --charts weird-chart
Linting charts...
Version increment checking disabled.
------------------------------------------------------------------------------------------------------------------------
 Configuration
------------------------------------------------------------------------------------------------------------------------
Remote: origin
TargetBranch: master
BuildId: 
LintConf: lintconf.yaml
ChartYamlSchema: chart_schema.yaml
ValidateMaintainers: true
ValidateChartSchema: true
ValidateYaml: true
CheckVersionIncrement: false
ProcessAllCharts: false
Charts: [weird-chart]
ChartRepos: []
ChartDirs: [.]
ExcludedCharts: []
HelmExtraArgs: 
HelmRepoExtraArgs: []
Debug: false
Upgrade: false
SkipMissingValues: false
Namespace: 
ReleaseLabel: 
------------------------------------------------------------------------------------------------------------------------

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 weird-chart => (version: "1.0.0", path: "weird-chart")
------------------------------------------------------------------------------------------------------------------------

Linting chart 'weird-chart => (version: "1.0.0", path: "weird-chart")'
Validating /Users/steved/src/chart-testing/etc/weird-chart/Chart.yaml...
Validation success! 👍
Validating maintainers...
------------------------------------------------------------------------------------------------------------------------
 ✖︎ weird-chart => (version: "1.0.0", path: "weird-chart") > Chart doesn't have maintainers
------------------------------------------------------------------------------------------------------------------------
Error: Error linting charts: Error processing charts
Error linting charts: Error processing charts
exit status 1

```

**Which issue this PR fixes**: fixes #209

**Special notes for your reviewer**:
https://github.com/spf13/cobra/issues/340 is this upstream cobra issue.