### PR TITLE
Check if linter executables are on $PATH

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -127,6 +127,7 @@ type Kubectl interface {
 //
 // Yamale runs `yamale` on the specified file with the specified schema file
 type Linter interface {
+	ExecutablesExist() error
 	YamlLint(yamlFile string, configFile string) error
 	Yamale(yamlFile string, schemaFile string) error
 }
@@ -270,6 +271,11 @@ func NewTesting(config config.Configuration) (Testing, error) {
 
 	if version.Major() < 3 {
 		return testing, fmt.Errorf("minimum required Helm version is v3.0.0; found: %s", version)
+	}
+
+	err = testing.linter.ExecutablesExist()
+	if err != nil {
+		return testing, err
 	}
 	return testing, nil
 }

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -88,6 +88,9 @@ func (l *fakeLinter) Yamale(yamlFile, schemaFile string) error {
 	l.Called(yamlFile, schemaFile)
 	return nil
 }
+func (l *fakeLinter) ExecutablesExist() error {
+	return nil
+}
 
 type fakeHelm struct{}
 

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -132,3 +132,12 @@ func (p ProcessExecutor) RunWithProxy(withProxy fn) error {
 
 	return nil
 }
+
+func (p ProcessExecutor) ExecutableExists(executable string) error {
+	_, err := exec.LookPath(executable)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/tool/linter.go
+++ b/pkg/tool/linter.go
@@ -26,6 +26,18 @@ func NewLinter(exec exec.ProcessExecutor) Linter {
 	}
 }
 
+func (l Linter) ExecutablesExist() error {
+	if err := l.exec.ExecutableExists("yamllint"); err != nil {
+		return err
+	}
+
+	if err := l.exec.ExecutableExists("yamale"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (l Linter) YamlLint(yamlFile string, configFile string) error {
 	return l.exec.RunProcess("yamllint", "--config-file", configFile, yamlFile)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Checks that the `yamllint` and `yamale` executables are on `$PATH` to aid in debugging local installations.

**Which issue this PR fixes**: fixes #216

**Special notes for your reviewer**:
This generates the following output if ie. `yamale` does not exist.
```
Linting charts...
Version increment checking disabled.
------------------------------------------------------------------------------------------------------------------------
 Configuration
------------------------------------------------------------------------------------------------------------------------
Remote: origin
TargetBranch: master
BuildId: 
LintConf: /home/lucasb/.ct/lintconf.yaml
ChartYamlSchema: /home/lucasb/.ct/chart_schema.yaml
ValidateMaintainers: true
ValidateChartSchema: true
ValidateYaml: true
CheckVersionIncrement: false
ProcessAllCharts: true
Charts: []
ChartRepos: []
ChartDirs: [charts]
ExcludedCharts: []
HelmExtraArgs: 
HelmRepoExtraArgs: []
Debug: false
Upgrade: false
SkipMissingValues: false
Namespace: 
ReleaseLabel: 
------------------------------------------------------------------------------------------------------------------------
Error: exec: "yamale": executable file not found in $PATH
Usage:
  ct lint [flags]

Flags:
      --all                            Process all charts except those explicitly excluded.
                                       Disables changed charts detection and version increment checking
      --chart-dirs strings             Directories containing Helm charts. May be specified multiple times
                                       or separate values with commas (default [charts])
      --chart-repos strings            Additional chart repositories for dependency resolutions.
                                       Repositories should be formatted as 'name=url' (ex: local=http://127.0.0.1:8879/charts).
                                       May be specified multiple times or separate values with commas
      --chart-yaml-schema string       The schema for chart.yml validation. If not specified, 'chart_schema.yaml'
                                       is searched in the current directory, '$HOME/.ct', and '/etc/ct', in
                                       that order.
      --charts strings                 Specific charts to test. Disables changed charts detection and
                                       version increment checking. May be specified multiple times
                                       or separate values with commas
      --check-version-increment        Activates a check for chart version increments (default: true) (default true)
      --config string                  Config file
      --debug                          Print CLI calls of external tools to stdout (Note: depending on helm-extra-args
                                       passed, this may reveal sensitive data)
      --excluded-charts strings        Charts that should be skipped. May be specified multiple times
                                       or separate values with commas
      --helm-repo-extra-args strings   Additional arguments for the 'helm repo add' command to be
                                       specified on a per-repo basis with an equals sign as delimiter
                                       (e.g. 'myrepo=--username test --password secret'). May be specified
                                       multiple times or separate values with commas
  -h, --help                           help for lint
      --lint-conf string               The config file for YAML linting. If not specified, 'lintconf.yaml'
                                       is searched in the current directory, '$HOME/.ct', and '/etc/ct', in
                                       that order
      --remote string                  The name of the Git remote used to identify changed charts (default "origin")
      --target-branch string           The name of the target branch used to identify changed charts (default "master")
      --validate-chart-schema          Enable schema validation of 'Chart.yaml' using Yamale (default: true) (default true)
      --validate-maintainers           Enable validation of maintainer account names in chart.yml (default: true).
                                       Works for GitHub, GitLab, and Bitbucket (default true)
      --validate-yaml                  Enable linting of 'Chart.yaml' and values files (default: true) (default true)

exec: "yamale": executable file not found in $PATH
```
It took me way to long to debug my local installation because it was just throwing `Error: Error linting charts: Error processing charts`.