### PR TITLE
Adding the apiVersion as a required field in the Chart.yaml validation

### DIFF
--- a/etc/chart_schema.yaml
+++ b/etc/chart_schema.yaml
@@ -1,6 +1,7 @@
 name: str()
 home: str()
 version: str()
+apiVersion: str()
 appVersion: any(str(), num())
 description: str()
 keywords: list(str(), required=False)


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds the `apiVersion` as a required field in `Chart.yaml` as per the Helm documentation.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/helm/chart-testing/issues/221

**Special notes for your reviewer**:
N/a