### PR TITLE
Revert "Use latest upstream instead of local branch for tags (#153)"

### DIFF
--- a/tag.sh
+++ b/tag.sh
@@ -97,8 +97,7 @@ main() {
 
     pushd "$SCRIPT_DIR" > /dev/null
 
-    git fetch "$remote"
-    git tag -a -m "Release $tag" "$tag" "$remote/master" "${force[@]}"
+    git tag -a -m "Release $tag" "$tag" "${force[@]}"
 
     if [[ -z "$skip_push" ]]; then
         git push "$remote" "refs/tags/$tag" "${force[@]}"


### PR DESCRIPTION
This reverts commit 5cb2b8c2359e3402a7f4122c2a1acb235a8f30d9 because it
prevented releasing bug fixes for previous versions from non-master
branches.

Signed-off-by: Reinhard Naegele <unguiculus@gmail.com>
