### PR TITLE
Add Homebrew installer

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -56,3 +56,18 @@ dockers:
     extra_files:
       - etc/chart_schema.yaml
       - etc/lintconf.yaml
+brews:
+  - github:
+      owner: helm
+      name: homebrew-tap
+    commit_author:
+      name: helm-bot
+      email: helm-bot@users.noreply.github.com
+    folder: Formula
+    homepage: https://github.com/helm/chart-testing/
+    description: Testing and linting Helm charts
+    install: |
+      bin.install "ct"
+      etc.install "etc" => "ct"
+    test: |
+      system "#{bin}/ct version"

--- a/README.md
+++ b/README.md
@@ -34,15 +34,12 @@ Unpack the `ct` binary, add it to your PATH, and you are good to go!
 A Docker image is available at `quay.io/helmpack/chart-testing` with list of
 available tags [here](https://quay.io/repository/helmpack/chart-testing?tab=tags).
 
-### From Source
+### Homebrew
 
-To install from head with [Go](https://golang.org) 1.14 or higher:
-
-```cli
-go get github.com/helm/chart-testing/v3/ct
+```console
+$ brew tap helm/tap
+$ brew install chart-testing
 ```
-
-This will put `ct` in `$(go env GOPATH)/bin`. You may need to add that directory to your `$PATH` as shown [here](https://golang.org/doc/code.html#GOPATH) if you encounter the error `ct: command not found` after installation.
 
 ## Usage
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,6 +34,7 @@ var (
 	configSearchLocations = []string{
 		".",
 		path.Join(homeDir, ".ct"),
+		"/usr/local/etc/ct",
 		"/etc/ct",
 	}
 )


### PR DESCRIPTION
The Homebrew formula installs the config files to Homebrew's
etc directory, so we add that to the search locations for config files.

Signed-off-by: Reinhard Nägele <unguiculus@gmail.com>
