### PR TITLE
Migrate chart-testing formula to homebrew/core

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -56,18 +56,3 @@ dockers:
     extra_files:
       - etc/chart_schema.yaml
       - etc/lintconf.yaml
-brews:
-  - github:
-      owner: helm
-      name: homebrew-tap
-    commit_author:
-      name: helm-bot
-      email: helm-bot@users.noreply.github.com
-    folder: Formula
-    homepage: https://github.com/helm/chart-testing/
-    description: Testing and linting Helm charts
-    install: |
-      bin.install "ct"
-      etc.install "etc" => "ct"
-    test: |
-      system "#{bin}/ct version"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ available tags [here](https://quay.io/repository/helmpack/chart-testing?tab=tags
 ### Homebrew
 
 ```console
-$ brew tap helm/tap
 $ brew install chart-testing
 ```
 


### PR DESCRIPTION
Signed-off-by: Alexander Zigelski <ali@crunchtime.dev>

Congratulations! 🎉 The formula `chart-testing` has been migrated to `homebrew-core` 🍺 
This means that the `homebrew` community will co-author the formula and the formula is even easier to install (via `brew install chart-testing`).

**What this PR does**:

This PR changes the instructions on how to install `chart-testing` on macOS. It also removes the tap configuration from `goreleaser` which prevents your own tap to be updated. The formula will be updated by the Homebrew community (e.g. automatically via `brew bump-formula-pr chart-testing $VERSION` which is triggered automatically by GitLab CI action in one of my private repos).
If you plan to automate `chart-testing` GitHub releases we can also include a GitHub action that automatically create a PR against `homebrew-core`. You can see an example on how to accomplish this in the `release.yaml` here https://github.com/argoproj/argo-cd/pull/3979/files

Here is the accompanying PR in your tap repo: https://github.com/helm/homebrew-tap/pull/1
