### PR TITLE
Bump docker image helm verison to 3.2.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$kubectl
     mv kubectl /usr/local/bin/
 
 # Install Helm
-ARG helm_version=v3.1.2
+ARG helm_version=v3.2.4
 LABEL helm_version=$helm_version
 RUN curl -LO "https://get.helm.sh/helm-$helm_version-linux-amd64.tar.gz" && \
     mkdir -p "/usr/local/helm-$helm_version" && \


### PR DESCRIPTION
**What this PR does / why we need it**: Bumps the helm version in the docker image to the latest 3.2.4

**Which issue this PR fixes** : fixes #249 

**Special notes for your reviewer**: This tool is great, thanks!
