### PR TITLE
Add type field to chart schema

### DIFF
--- a/etc/chart_schema.yaml
+++ b/etc/chart_schema.yaml
@@ -14,6 +14,7 @@ tags: str(required=False)
 deprecated: bool(required=False)
 kubeVersion: str(required=False)
 annotations: map(str(), str(), required=False)
+type: str(required=False)
 ---
 maintainer:
   name: str()


### PR DESCRIPTION
**What this PR does / why we need it**: Adds the `type` field to the chart schema. This field is generated by `helm create` and is also described in the [documentation](https://helm.sh/docs/topics/charts/#the-chartyaml-file).

**Which issue this PR fixes**: fixes #251 

**Special notes for your reviewer**: `chart-testing` is awesome!
