### PR TITLE
Bump docker image versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,22 @@
-FROM alpine:3.11
+FROM alpine:3.12
 
 RUN apk --no-cache add \
     curl \
     git \
     libc6-compat \
     openssh-client \
-    python \
-    py-crcmod \
-    py-pip && \
-    pip install --upgrade pip==18.1
+    py3-pip \
+    py3-wheel \
+    python3 \
+    && pip install --upgrade pip==20.2.1
 
 # Install a YAML Linter
-ARG yamllint_version=1.21.0
+ARG yamllint_version=1.24.2
 LABEL yamllint_version=$yamllint_version
 RUN pip install "yamllint==$yamllint_version"
 
 # Install Yamale YAML schema validator
-ARG yamale_version=2.0.1
+ARG yamale_version=3.0.2
 LABEL yamale_version=$yamale_version
 RUN pip install "yamale==$yamale_version"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN apk --no-cache add \
     openssh-client \
     py3-pip \
     py3-wheel \
-    python3 \
-    && pip install --upgrade pip==20.2.1
+    python3 && \
+    pip install --upgrade pip==20.2.1
 
 # Install a YAML Linter
 ARG yamllint_version=1.24.2


### PR DESCRIPTION
**What this PR does / why we need it**: This PR bumps the version of the base image, and the tools within it, to their latest versions.

**Which issue this PR fixes**: supersedes #234 

**Special notes for your reviewer**: I notice that #234 has a request for extra testing, so I've built an image that contains #250, #251, and this PR. It's available [here](https://hub.docker.com/layers/smlx/chart-testing/v3.0.0-patch.1/images/sha256-b8f60684a36bd422a1fe9a8e97cf336584118f89f409a4b99114a2945cb1e5c1?context=explore). I've also tested this image [here](https://github.com/amazeeio/charts/runs/949550295) in the chart-testing lint action.
