### PR TITLE
Retry kubectl download on transient network errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$kubectl
 # Install Helm
 ARG helm_version=v3.1.2
 LABEL helm_version=$helm_version
-RUN curl -LO "https://get.helm.sh/helm-$helm_version-linux-amd64.tar.gz" && \
+RUN curl -LO --retry 2 "https://get.helm.sh/helm-$helm_version-linux-amd64.tar.gz" && \
     mkdir -p "/usr/local/helm-$helm_version" && \
     tar -xzf "helm-$helm_version-linux-amd64.tar.gz" -C "/usr/local/helm-$helm_version" && \
     ln -s "/usr/local/helm-$helm_version/linux-amd64/helm" /usr/local/bin/helm && \


### PR DESCRIPTION
**What this PR does / why we need it**: This PR makes docker image builds more resilient by retrying the `kubectl` download on transient network errors.

**Which issue this PR fixes**: fixes build failures like [this one](https://app.circleci.com/pipelines/github/helm/chart-testing/216/workflows/aee560b9-d93f-49be-866e-fd6854d36515/jobs/1451/parallel-runs/0/steps/0-105).

**Special notes for your reviewer**: n/a
