### PR TITLE
Fix int to string conversion

### DIFF
--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -16,6 +16,7 @@ package util
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,7 +34,7 @@ func TestFlatten(t *testing.T) {
 	}
 
 	for index, testData := range testDataSlice {
-		t.Run(string(index), func(t *testing.T) {
+		t.Run(strconv.Itoa(index), func(t *testing.T) {
 			actual, err := Flatten(testData.input)
 			assert.Equal(t, testData.expected, actual)
 			if testData.expected != nil {
@@ -61,7 +62,7 @@ func TestCompareVersions(t *testing.T) {
 	}
 
 	for index, testData := range testDataSlice {
-		t.Run(string(index), func(t *testing.T) {
+		t.Run(strconv.Itoa(index), func(t *testing.T) {
 			actual, _ := CompareVersions(testData.oldVersion, testData.newVersion)
 			assert.Equal(t, testData.expected, actual)
 		})
@@ -83,7 +84,7 @@ func TestSanitizeName(t *testing.T) {
 	}
 
 	for index, testData := range testDataSlice {
-		t.Run(string(index), func(t *testing.T) {
+		t.Run(strconv.Itoa(index), func(t *testing.T) {
 			actual := SanitizeName(testData.input, testData.maxLength)
 			fmt.Printf("actual: %s,%d, input: %s,%d\n", actual, len(actual), testData.input, testData.maxLength)
 			assert.Equal(t, testData.expected, actual)
@@ -111,7 +112,7 @@ func TestBreakingChangeAllowed(t *testing.T) {
 	}
 
 	for index, testData := range testDataSlice {
-		t.Run(string(index), func(t *testing.T) {
+		t.Run(strconv.Itoa(index), func(t *testing.T) {
 			actual, _ := BreakingChangeAllowed(testData.left, testData.right)
 			assert.Equal(t, testData.breaking, actual, fmt.Sprintf("input: %s,%s\n", testData.left, testData.right))
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:

The old code was incorrect and no longer builds with Go 1.15 when running `go test`.

See the 1.15 release notes here: https://golang.org/doc/go1.15#vet

**Which issue this PR fixes**: n/a

**Special notes for your reviewer**: none.
