### PR TITLE
Add flag for disabling config printing

### DIFF
--- a/ct/cmd/install.go
+++ b/ct/cmd/install.go
@@ -82,7 +82,11 @@ func addInstallFlags(flags *flag.FlagSet) {
 func install(cmd *cobra.Command, args []string) error {
 	fmt.Println("Installing charts...")
 
-	configuration, err := config.LoadConfiguration(cfgFile, cmd, true)
+	printConfig, err := cmd.Flags().GetBool("print-config")
+	if err != nil {
+		return err
+	}
+	configuration, err := config.LoadConfiguration(cfgFile, cmd, printConfig)
 	if err != nil {
 		return fmt.Errorf("Error loading configuration: %s", err)
 	}

--- a/ct/cmd/lint.go
+++ b/ct/cmd/lint.go
@@ -74,7 +74,11 @@ func addLintFlags(flags *flag.FlagSet) {
 func lint(cmd *cobra.Command, args []string) error {
 	fmt.Println("Linting charts...")
 
-	configuration, err := config.LoadConfiguration(cfgFile, cmd, true)
+	printConfig, err := cmd.Flags().GetBool("print-config")
+	if err != nil {
+		return err
+	}
+	configuration, err := config.LoadConfiguration(cfgFile, cmd, printConfig)
 	if err != nil {
 		return fmt.Errorf("Error loading configuration: %s", err)
 	}

--- a/ct/cmd/root.go
+++ b/ct/cmd/root.go
@@ -92,7 +92,9 @@ func addCommonLintAndInstallFlags(flags *pflag.FlagSet) {
 		(e.g. 'myrepo=--username test --password secret'). May be specified
 		multiple times or separate values with commas`))
 	flags.Bool("debug", false, heredoc.Doc(`
-		Print CLI calls of external tools to stdout (Note: depending on helm-extra-args
-		passed, this may reveal sensitive data)`))
-	flags.Bool("print-config", true, "Prints the configuration to stdout")
+		Print CLI calls of external tools to stdout (caution: setting this may
+		expose sensitive data when helm-repo-extra-args contains passwords)`))
+	flags.Bool("print-config", false, heredoc.Doc(`
+		Prints the configuration to stdout (caution: setting this may
+		expose sensitive data when helm-repo-extra-args contains passwords)`))
 }

--- a/ct/cmd/root.go
+++ b/ct/cmd/root.go
@@ -94,4 +94,5 @@ func addCommonLintAndInstallFlags(flags *pflag.FlagSet) {
 	flags.Bool("debug", false, heredoc.Doc(`
 		Print CLI calls of external tools to stdout (Note: depending on helm-extra-args
 		passed, this may reveal sensitive data)`))
+	flags.Bool("print-config", true, "Prints the configuration to stderr")
 }

--- a/ct/cmd/root.go
+++ b/ct/cmd/root.go
@@ -94,5 +94,5 @@ func addCommonLintAndInstallFlags(flags *pflag.FlagSet) {
 	flags.Bool("debug", false, heredoc.Doc(`
 		Print CLI calls of external tools to stdout (Note: depending on helm-extra-args
 		passed, this may reveal sensitive data)`))
-	flags.Bool("print-config", true, "Prints the configuration to stderr")
+	flags.Bool("print-config", true, "Prints the configuration to stdout")
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"path"
 	"reflect"
 	"strings"
@@ -97,7 +98,7 @@ func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*C
 		}
 	} else {
 		if printConfig {
-			fmt.Println("Using config file: ", v.ConfigFileUsed())
+			fmt.Fprintln(os.Stderr, "Using config file: ", v.ConfigFileUsed())
 		}
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,7 +16,6 @@ package config
 
 import (
 	"fmt"
-	"os"
 	"path"
 	"reflect"
 	"strings"
@@ -97,9 +96,7 @@ func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*C
 			return nil, errors.Wrap(err, "Error loading config file")
 		}
 	} else {
-		if printConfig {
-			fmt.Fprintln(os.Stderr, "Using config file: ", v.ConfigFileUsed())
-		}
+		fmt.Println("Using config file:", v.ConfigFileUsed())
 	}
 
 	isLint := strings.Contains(cmd.Use, "lint")


### PR DESCRIPTION
By default, ct prints the config on startup. This can be problematic
because it may contain senstivie data when helm-repo-extra-args contains
passwords. The new flag enables turning off config printing.

Signed-off-by: Reinhard Nägele <unguiculus@gmail.com>
