### PR TITLE
Add support for helm unittest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,13 @@ RUN curl -LO "https://get.helm.sh/helm-$helm_version-linux-amd64.tar.gz" && \
     ln -s "/usr/local/helm-$helm_version/linux-amd64/helm" /usr/local/bin/helm && \
     rm -f "helm-$helm_version-linux-amd64.tar.gz"
 
+# Install Helm unittest
+ARG helm_unittest_version=0.2.4
+LABEL helm_unittest_version=${helm_unittest_version}
+RUN curl -LO https://github.com/quintush/helm-unittest/releases/download/v${helm_unittest_version}/helm-unittest-linux-amd64-${helm_unittest_version}.tgz && \
+    mkdir -p ${HOME}/.local/share/helm/plugins/unittest && \
+    tar xzf helm-unittest-linux-amd64-${helm_unittest_version}.tgz -C ${HOME}/.local/share/helm/plugins/unittest
+
 COPY ./etc/chart_schema.yaml /etc/ct/chart_schema.yaml
 COPY ./etc/lintconf.yaml /etc/ct/lintconf.yaml
 COPY ct /usr/local/bin/ct

--- a/ct/cmd/lint.go
+++ b/ct/cmd/lint.go
@@ -69,6 +69,8 @@ func addLintFlags(flags *flag.FlagSet) {
 			Enable schema validation of 'Chart.yaml' using Yamale (default: true)`))
 	flags.Bool("validate-yaml", true, heredoc.Doc(`
 			Enable linting of 'Chart.yaml' and values files (default: true)`))
+	flags.Bool("run-unittests", true, heredoc.Doc(`
+			Enable helm unittest (default: true)`))
 }
 
 func lint(cmd *cobra.Command, args []string) error {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,6 +50,7 @@ type Configuration struct {
 	ValidateMaintainers   bool     `mapstructure:"validate-maintainers"`
 	ValidateChartSchema   bool     `mapstructure:"validate-chart-schema"`
 	ValidateYaml          bool     `mapstructure:"validate-yaml"`
+	UnitTests             bool     `mapstructure:"run-unittests"`
 	CheckVersionIncrement bool     `mapstructure:"check-version-increment"`
 	ProcessAllCharts      bool     `mapstructure:"all"`
 	Charts                []string `mapstructure:"charts"`

--- a/pkg/tool/tester.go
+++ b/pkg/tool/tester.go
@@ -1,0 +1,19 @@
+package tool
+
+import (
+	"github.com/helm/chart-testing/v3/pkg/exec"
+)
+
+type Tester struct {
+	exec exec.ProcessExecutor
+}
+
+func NewTester(exec exec.ProcessExecutor) Tester {
+	return Tester{
+		exec: exec,
+	}
+}
+
+func (t Tester) RunUnitTests(chartDirectory string) error {
+	return t.exec.RunProcess("helm", "unittest", "-f", "tests/*.yaml", chartDirectory)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/chart-testing.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

It adds support for helm [unittest](https://github.com/quintush/helm-unittest).
ct does a great job on linting and testing charts. My feeling is that helm-unittest could be a good additions, as it allows to write tests for different values. ct also support different values, by putting them in the `ci` directory, but installing all kinds of different combinations is often not very practical. Unit tests, which verify rendered manifest for certain content could be a good addition.

https://github.com/jenkinsci/helm-charts/pull/73/checks?check_run_id=1178518653#step:4:84 shows how this would look like.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

This is not finished. It's meant to get feedback on the functionality.
