### PR TITLE
Add option to exclude deprecated charts

### DIFF
--- a/ct/cmd/root.go
+++ b/ct/cmd/root.go
@@ -74,6 +74,7 @@ func addCommonFlags(flags *pflag.FlagSet) {
 	flags.Bool("print-config", false, heredoc.Doc(`
 		Prints the configuration to stderr (caution: setting this may
 		expose sensitive data when helm-repo-extra-args contains passwords)`))
+	flags.Bool("exclude-deprecated", false, "Skip charts that are marked as deprecated")
 }
 
 func addCommonLintAndInstallFlags(flags *pflag.FlagSet) {

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -297,7 +297,7 @@ func (t *Testing) processCharts(action func(chart *Chart) TestResult) ([]TestRes
 		}
 
 		if t.config.ExcludeDeprecated && chart.yaml.Deprecated {
-			fmt.Printf("Chart %s is deprecated, and will be ignored due to the ExcludeDeprecated configuration option\n", chart.String())
+			fmt.Printf("Chart '%s' is deprecated and will be ignored because '--exclude-deprecated' is set\n", chart.String())
 		} else {
 			charts = append(charts, chart)
 		}

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -295,7 +295,12 @@ func (t *Testing) processCharts(action func(chart *Chart) TestResult) ([]TestRes
 		if err != nil {
 			return nil, err
 		}
-		charts = append(charts, chart)
+
+		if t.config.ExcludeDeprecated && chart.yaml.Deprecated {
+			fmt.Printf("Chart %s is deprecated, and will be ignored due to the ExcludeDeprecated configuration option\n", chart.String())
+		} else {
+			charts = append(charts, chart)
+		}
 	}
 
 	fmt.Println()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -63,6 +63,7 @@ type Configuration struct {
 	SkipMissingValues     bool     `mapstructure:"skip-missing-values"`
 	Namespace             string   `mapstructure:"namespace"`
 	ReleaseLabel          string   `mapstructure:"release-label"`
+	ExcludeDeprecated     bool     `mapstructure:"exclude-deprecated"`
 }
 
 func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*Configuration, error) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -53,4 +53,5 @@ func loadAndAssertConfigFromFile(t *testing.T, configFile string) {
 	require.Equal(t, true, cfg.SkipMissingValues)
 	require.Equal(t, "default", cfg.Namespace)
 	require.Equal(t, "release", cfg.ReleaseLabel)
+	require.Equal(t, true, cfg.ExcludeDeprecated)
 }

--- a/pkg/config/test_config.json
+++ b/pkg/config/test_config.json
@@ -28,5 +28,6 @@
     "upgrade": true,
     "skip-missing-values": true,
     "namespace": "default",
-    "release-label": "release"
+    "release-label": "release",
+    "exclude-deprecated": true
 }

--- a/pkg/config/test_config.yaml
+++ b/pkg/config/test_config.yaml
@@ -24,3 +24,4 @@ upgrade: true
 skip-missing-values: true
 namespace: default
 release-label: release
+exclude-deprecated: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a new configuration option that allows a user to exclude deprecated charts from testing.

**Which issue this PR fixes**
fixes #261

**Special notes for your reviewer**:
I was able to validate some of the behavior manually by linting a deprecated chart, unsure about the best approach to automate that testing, perhaps in the integration_test.go tests.
Decided to hold off on implementing for now, as I realize this flag might need to be discussed.