### PR TITLE
Support execution of additional commands during ct lint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.12
 
 RUN apk --no-cache add \
+    bash \
     curl \
     git \
     libc6-compat \

--- a/ct/cmd/lint.go
+++ b/ct/cmd/lint.go
@@ -70,7 +70,10 @@ func addLintFlags(flags *flag.FlagSet) {
 	flags.Bool("validate-yaml", true, heredoc.Doc(`
 			Enable linting of 'Chart.yaml' and values files (default: true)`))
 	flags.StringSlice("additional-commands", []string{}, heredoc.Doc(`
-			Additional command to run per chart (default: [])`))
+            Additional commands to run per chart (default: [])
+            Commands will be executed in the same order as provided in the list and will
+            be rendered with go template before being executed.
+            Example: "helm unittest --helm3 -f tests/*.yaml {{ .Path }}"`))
 }
 
 func lint(cmd *cobra.Command, args []string) error {

--- a/ct/cmd/lint.go
+++ b/ct/cmd/lint.go
@@ -69,6 +69,8 @@ func addLintFlags(flags *flag.FlagSet) {
 			Enable schema validation of 'Chart.yaml' using Yamale (default: true)`))
 	flags.Bool("validate-yaml", true, heredoc.Doc(`
 			Enable linting of 'Chart.yaml' and values files (default: true)`))
+	flags.StringSlice("additional-commands", []string{}, heredoc.Doc(`
+			Additional command to run per chart (default: [])`))
 }
 
 func lint(cmd *cobra.Command, args []string) error {

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/goreleaser/goreleaser v0.129.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/go-retryablehttp v0.6.4
+	github.com/mattn/go-shellwords v1.0.10
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.2.2 // indirect
 	github.com/pelletier/go-toml v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -219,6 +219,8 @@ github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.11 h1:FxPOTFNqGkuDUGi3H/qkUbQO4ZiBa2brKq5r0l8TGeM=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
+github.com/mattn/go-shellwords v1.0.10 h1:Y7Xqm8piKOO3v10Thp7Z36h4FYFjt5xB//6XvOrs2Gw=
+github.com/mattn/go-shellwords v1.0.10/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/go-zglob v0.0.1 h1:xsEx/XUoVlI6yXjqBK062zYhRTZltCNmYPx6v+8DNaY=
 github.com/mattn/go-zglob v0.0.1/go.mod h1:9fxibJccNxU2cnpIKLRRFA7zX7qhkJIQWBb449FYHOo=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -261,7 +261,7 @@ func NewTesting(config config.Configuration) (Testing, error) {
 		git:              tool.NewGit(procExec),
 		kubectl:          tool.NewKubectl(procExec),
 		linter:           tool.NewLinter(procExec),
-		cmdExecutor:      tool.NewTester(procExec),
+		cmdExecutor:      tool.NewCmdTemplateExecutor(procExec),
 		accountValidator: tool.AccountValidator{},
 		directoryLister:  util.DirectoryLister{},
 		chartUtils:       util.ChartUtils{},

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -131,6 +131,13 @@ type Linter interface {
 	Yamale(yamlFile string, schemaFile string) error
 }
 
+// CmdExecutor is the interface
+//
+// RunCommand renders cmdTemplate as go template using data and executes the resulting command
+type CmdExecutor interface {
+	RunCommand(cmdTemplate string, data interface{}) error
+}
+
 // DirectoryLister is the interface
 //
 // ListChildDirs lists direct child directories of parentDir given they pass the test function
@@ -224,6 +231,7 @@ type Testing struct {
 	kubectl                  Kubectl
 	git                      Git
 	linter                   Linter
+	cmdExecutor              CmdExecutor
 	accountValidator         AccountValidator
 	directoryLister          DirectoryLister
 	chartUtils               ChartUtils
@@ -253,6 +261,7 @@ func NewTesting(config config.Configuration) (Testing, error) {
 		git:              tool.NewGit(procExec),
 		kubectl:          tool.NewKubectl(procExec),
 		linter:           tool.NewLinter(procExec),
+		cmdExecutor:      tool.NewTester(procExec),
 		accountValidator: tool.AccountValidator{},
 		directoryLister:  util.DirectoryLister{},
 		chartUtils:       util.ChartUtils{},
@@ -446,6 +455,13 @@ func (t *Testing) LintChart(chart *Chart) TestResult {
 
 	if t.config.ValidateMaintainers {
 		if err := t.ValidateMaintainers(chart); err != nil {
+			result.Error = err
+			return result
+		}
+	}
+
+	for _, cmd := range t.config.AdditionalCommands {
+		if err := t.cmdExecutor.RunCommand(cmd, chart); err != nil {
 			result.Error = err
 			return result
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,6 +50,7 @@ type Configuration struct {
 	ValidateMaintainers   bool     `mapstructure:"validate-maintainers"`
 	ValidateChartSchema   bool     `mapstructure:"validate-chart-schema"`
 	ValidateYaml          bool     `mapstructure:"validate-yaml"`
+	AdditionalCommands    []string `mapstructure:"additional-commands"`
 	CheckVersionIncrement bool     `mapstructure:"check-version-increment"`
 	ProcessAllCharts      bool     `mapstructure:"all"`
 	Charts                []string `mapstructure:"charts"`

--- a/pkg/tool/cmdexecutor.go
+++ b/pkg/tool/cmdexecutor.go
@@ -22,9 +22,5 @@ func (t CmdTemplateExecutor) RunCommand(cmdTemplate string, data interface{}) er
 	var b strings.Builder
 	err := template.Execute(&b, data)
 	renderedCommand := b.String()
-	split := strings.Split(renderedCommand, " ")
-	if err != nil {
-		return err
-	}
-	return t.exec.RunProcess(split[0], split[1:])
+	return t.exec.RunProcess("sh", "-c", renderedCommand)
 }

--- a/pkg/tool/cmdexecutor.go
+++ b/pkg/tool/cmdexecutor.go
@@ -4,15 +4,18 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/helm/chart-testing/v3/pkg/exec"
 	"github.com/mattn/go-shellwords"
 )
 
-type CmdTemplateExecutor struct {
-	exec exec.ProcessExecutor
+type ProcessExecutor interface {
+	RunProcess(executable string, execArgs ...interface{}) error
 }
 
-func NewCmdTemplateExecutor(exec exec.ProcessExecutor) CmdTemplateExecutor {
+type CmdTemplateExecutor struct {
+	exec ProcessExecutor
+}
+
+func NewCmdTemplateExecutor(exec ProcessExecutor) CmdTemplateExecutor {
 	return CmdTemplateExecutor{
 		exec: exec,
 	}

--- a/pkg/tool/cmdexecutor.go
+++ b/pkg/tool/cmdexecutor.go
@@ -1,0 +1,30 @@
+package tool
+
+import (
+	"strings"
+	"text/template"
+
+	"github.com/helm/chart-testing/v3/pkg/exec"
+)
+
+type CmdTemplateExecutor struct {
+	exec exec.ProcessExecutor
+}
+
+func NewTester(exec exec.ProcessExecutor) CmdTemplateExecutor {
+	return CmdTemplateExecutor{
+		exec: exec,
+	}
+}
+
+func (t CmdTemplateExecutor) RunCommand(cmdTemplate string, data interface{}) error {
+	var template = template.Must(template.New("command").Parse(cmdTemplate))
+	var b strings.Builder
+	err := template.Execute(&b, data)
+	renderedCommand := b.String()
+	split := strings.Split(renderedCommand, " ")
+	if err != nil {
+		return err
+	}
+	return t.exec.RunProcess(split[0], split[1:])
+}

--- a/pkg/tool/cmdexecutor.go
+++ b/pkg/tool/cmdexecutor.go
@@ -5,6 +5,7 @@ import (
 	"text/template"
 
 	"github.com/helm/chart-testing/v3/pkg/exec"
+	"github.com/mattn/go-shellwords"
 )
 
 type CmdTemplateExecutor struct {
@@ -23,6 +24,12 @@ func (t CmdTemplateExecutor) RunCommand(cmdTemplate string, data interface{}) er
 	if err := template.Execute(&b, data); err != nil {
 		return err
 	}
-	renderedCommand := b.String()
-	return t.exec.RunProcess("sh", "-c", renderedCommand)
+	rendered := b.String()
+
+	words, err := shellwords.Parse(rendered)
+	name, args := words[0], words[1:]
+	if err != nil {
+		return err
+	}
+	return t.exec.RunProcess(name, args)
 }

--- a/pkg/tool/cmdexecutor.go
+++ b/pkg/tool/cmdexecutor.go
@@ -27,9 +27,9 @@ func (t CmdTemplateExecutor) RunCommand(cmdTemplate string, data interface{}) er
 	rendered := b.String()
 
 	words, err := shellwords.Parse(rendered)
-	name, args := words[0], words[1:]
 	if err != nil {
 		return err
 	}
+	name, args := words[0], words[1:]
 	return t.exec.RunProcess(name, args)
 }

--- a/pkg/tool/cmdexecutor.go
+++ b/pkg/tool/cmdexecutor.go
@@ -11,7 +11,7 @@ type CmdTemplateExecutor struct {
 	exec exec.ProcessExecutor
 }
 
-func NewTester(exec exec.ProcessExecutor) CmdTemplateExecutor {
+func NewCmdTemplateExecutor(exec exec.ProcessExecutor) CmdTemplateExecutor {
 	return CmdTemplateExecutor{
 		exec: exec,
 	}

--- a/pkg/tool/cmdexecutor.go
+++ b/pkg/tool/cmdexecutor.go
@@ -20,7 +20,9 @@ func NewCmdTemplateExecutor(exec exec.ProcessExecutor) CmdTemplateExecutor {
 func (t CmdTemplateExecutor) RunCommand(cmdTemplate string, data interface{}) error {
 	var template = template.Must(template.New("command").Parse(cmdTemplate))
 	var b strings.Builder
-	err := template.Execute(&b, data)
+	if err := template.Execute(&b, data); err != nil {
+		return err
+	}
 	renderedCommand := b.String()
 	return t.exec.RunProcess("sh", "-c", renderedCommand)
 }

--- a/pkg/tool/cmdexecutor_test.go
+++ b/pkg/tool/cmdexecutor_test.go
@@ -1,0 +1,76 @@
+package tool
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type fakeProcessExecutor struct {
+	mock.Mock
+}
+
+func (c *fakeProcessExecutor) RunProcess(executable string, execArgs ...interface{}) error {
+	c.Called(executable, execArgs[0])
+	return nil
+}
+
+func TestCmdTemplateExecutor_RunCommand(t *testing.T) {
+	type args struct {
+		cmdTemplate string
+		data        interface{}
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantErr  bool
+		validate func(t *testing.T, executor *fakeProcessExecutor)
+	}{
+		{
+			name: "command without arguments",
+			args: args{
+				cmdTemplate: "echo",
+				data:        nil,
+			},
+			validate: func(t *testing.T, executor *fakeProcessExecutor) {
+				executor.AssertCalled(t, "RunProcess", "echo", []string{})
+			},
+			wantErr: false,
+		},
+		{
+			name: "command with args",
+			args: args{
+				cmdTemplate: "echo hello world",
+			},
+			validate: func(t *testing.T, executor *fakeProcessExecutor) {
+				executor.AssertCalled(t, "RunProcess", "echo", []string{"hello", "world"})
+			},
+			wantErr: false,
+		},
+		{
+			name: "interpolate args",
+			args: args{
+				cmdTemplate: "helm unittest --helm3 -f tests/*.yaml {{ .Path }}",
+				data:        map[string]string{"Path": "charts/my-chart"},
+			},
+			validate: func(t *testing.T, executor *fakeProcessExecutor) {
+				executor.AssertCalled(t, "RunProcess", "helm", []string{"unittest", "--helm3", "-f", "tests/*.yaml", "charts/my-chart"})
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			processExecutor := new(fakeProcessExecutor)
+			processExecutor.On("RunProcess", mock.Anything, mock.Anything).Return(nil)
+			templateExecutor := CmdTemplateExecutor{
+				exec: processExecutor,
+			}
+			if err := templateExecutor.RunCommand(tt.args.cmdTemplate, tt.args.data); (err != nil) != tt.wantErr {
+				t.Errorf("RunCommand() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			tt.validate(t, processExecutor)
+
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/chart-testing.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

This is an alternative design to #279 which not only support `helm unittest`, but running any command as part of `ct lint`.
@unguiculus mentioned in slack that you would prefer that instead of pulling in additional dependencies.

I think that's totally valid and also solve many issue. When using #279 I noticed for example that it would be nice if I could pass additional parameters to the command. In that case I needed to add `--helm3`.

Given that helm unittest is installed locally or mounted into the chart testing container one could use this to run helm unittest for each chart with this configured in `ct.yaml`:

```
additional-commands:
 - helm unittest --helm3 -f tests/*.yaml {{ .Path }}
```

The command is treated as a go template. Like this it's possible to get the path to the chart as in the example. It would also be open for further extension if needed.

One idea would be to pass the information if it's an helm 2 or helm 3 chart.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

This works fine when ct is run locally and the toll is installed on your machine. If you want it in the container then the tool needs to be present there. There are multiple option to achieve this:

- built a custom image, which contains the tool
- mount a directory in case the tool has no dependencies
  PR helm/chart-testing-action/pull/54 adds support for it in chart-testing-action.