### PR TITLE
Log invalid chart dirs to stderr

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -17,6 +17,7 @@ package chart
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -729,7 +730,7 @@ func (t *Testing) ComputeChangedChartDirectories() ([]string, error) {
 				changedChartDirs = append(changedChartDirs, chartDir)
 			}
 		} else {
-			fmt.Printf("Directory '%s' is not a valid chart directory. Skipping...\n", dir)
+			fmt.Fprintf(os.Stderr, "Directory '%s' is not a valid chart directory. Skipping...\n", dir)
 		}
 	}
 


### PR DESCRIPTION
If directories are deleted from a chart, ct detects them as invalid
chart directories. A log message is printed to stdout which messes up
the regular output. In order to fix this, the message is now logged to
stderr.

*Example:*

```
$ ct list-changed
Directory 'charts/mychart/templates/deleted' is not a valid chart directory. Skipping...
charts/mychart
```

Signed-off-by: Reinhard Nägele <unguiculus@gmail.com>
