### PR TITLE
Ignore stderr when parsing Helm version

### DIFF
--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -40,6 +40,10 @@ func (p ProcessExecutor) RunProcessAndCaptureOutput(executable string, execArgs 
 	return p.RunProcessInDirAndCaptureOutput("", executable, execArgs)
 }
 
+func (p ProcessExecutor) RunProcessAndCaptureStdout(executable string, execArgs ...interface{}) (string, error) {
+	return p.RunProcessInDirAndCaptureStdout("", executable, execArgs)
+}
+
 func (p ProcessExecutor) RunProcessInDirAndCaptureOutput(workingDirectory string, executable string, execArgs ...interface{}) (string, error) {
 	cmd, err := p.CreateProcess(executable, execArgs...)
 	if err != nil {
@@ -48,6 +52,21 @@ func (p ProcessExecutor) RunProcessInDirAndCaptureOutput(workingDirectory string
 
 	cmd.Dir = workingDirectory
 	bytes, err := cmd.CombinedOutput()
+
+	if err != nil {
+		return "", errors.Wrap(err, "Error running process")
+	}
+	return strings.TrimSpace(string(bytes)), nil
+}
+
+func (p ProcessExecutor) RunProcessInDirAndCaptureStdout(workingDirectory string, executable string, execArgs ...interface{}) (string, error) {
+	cmd, err := p.CreateProcess(executable, execArgs...)
+	if err != nil {
+		return "", err
+	}
+
+	cmd.Dir = workingDirectory
+	bytes, err := cmd.Output()
 
 	if err != nil {
 		return "", errors.Wrap(err, "Error running process")

--- a/pkg/tool/helm.go
+++ b/pkg/tool/helm.go
@@ -84,5 +84,5 @@ func (h Helm) DeleteRelease(namespace string, release string) {
 }
 
 func (h Helm) Version() (string, error) {
-	return h.exec.RunProcessAndCaptureOutput("helm", "version", "--short")
+	return h.exec.RunProcessAndCaptureStdout("helm", "version", "--short")
 }


### PR DESCRIPTION
Helm v3.4.0 logs a warning about URL deprecation which causes semver
parsing to fail. We need to only read stdout and ignore stderr here.

Signed-off-by: Reinhard Nägele <unguiculus@gmail.com>
