### PR TITLE
Add docker authentication to CircleCI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ jobs:
   lint:
     docker:
       - image: koalaman/shellcheck-alpine
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
     steps:
       - checkout
       - run:
@@ -16,6 +19,9 @@ jobs:
     machine:
       enabled: true
       image: circleci/classic:201808-01
+      auth:
+        username: $DOCKER_USER
+        password: $DOCKER_PASS
     steps:
       - checkout
       - run:
@@ -47,6 +53,9 @@ jobs:
   build:
     docker:
       - image: cimg/go:1.14
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
     steps:
       - setup_remote_docker
       - checkout


### PR DESCRIPTION
**What this PR does / why we need it**:

Description taken from the linked issue
```
Starting November 1, 2020, Docker Hub will impose rate limits based on the originating IP. Since CircleCI runs jobs from a shared pool of IPs, it is highly recommended to use authenticated Docker pulls with Docker Hub to avoid rate limit problems.
```

**Which issue this PR fixes**

fixes #286

**Special notes for your reviewer**:

This is largely a copy of https://github.com/helm/helm/pull/8887

As I don't have access to CircleCI credentials I am unsure if additional work is required there so that this pipeline can use the credentials shown in the Helm pr.