### PR TITLE
extraArgs removed from uninstall command

### DIFF
--- a/pkg/tool/helm.go
+++ b/pkg/tool/helm.go
@@ -78,7 +78,7 @@ func (h Helm) Test(namespace string, release string) error {
 
 func (h Helm) DeleteRelease(namespace string, release string) {
 	fmt.Printf("Deleting release '%s'...\n", release)
-	if err := h.exec.RunProcess("helm", "uninstall", release, "--namespace", namespace, h.extraArgs); err != nil {
+	if err := h.exec.RunProcess("helm", "uninstall", release, "--namespace", namespace); err != nil {
 		fmt.Println("Error deleting Helm release:", err)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Ahmet Kaftan <ahmet.kaftan@cloudnesil.com>

<!--
Thank you for contributing to helm/chart-testing.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
When removing chart after chart install, `helm uninstall` command gets the `extraArgs` which has been added with `--helm-extra-args` flag.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #212

**Special notes for your reviewer**:
