### PR TITLE
Update helm2 version to 2.17.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$KUBECTL
     mv kubectl /usr/local/bin/
 
 # Install Helm
-ARG HELM_VERSION=v2.16.9
+ARG HELM_VERSION=v2.17.0
 RUN curl -LO "https://kubernetes-helm.storage.googleapis.com/helm-$HELM_VERSION-linux-amd64.tar.gz" && \
     mkdir -p "/usr/local/helm-$HELM_VERSION" && \
     tar -xzf "helm-$HELM_VERSION-linux-amd64.tar.gz" -C "/usr/local/helm-$HELM_VERSION" && \


### PR DESCRIPTION
switch helm stable chart to use the new location.

**What this PR does / why we need it**:

Update helm2 version to 2.17.0 to switch helm stable chart to use the new location.

**Which issue this PR fixes** *

N/A

**Special notes for your reviewer**:

N/A