### PR TITLE
Prepare release v2.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Run the script specifying the version for the new release.
 ./tag.sh --tag <release_version>
 ```
 
-Versions must start with a lower-case `v`, e. g. `v2.4.0`.
+Versions must start with a lower-case `v`, e. g. `v2.5.0`.
 
 
 ## Supported versions

--- a/etc/chart_schema.yaml
+++ b/etc/chart_schema.yaml
@@ -1,6 +1,7 @@
 name: str()
 home: str()
 version: str()
+apiVersion: str()
 appVersion: any(str(), num())
 description: str()
 keywords: list(str(), required=False)

--- a/examples/docker-for-mac/my_test.sh
+++ b/examples/docker-for-mac/my_test.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly IMAGE_TAG=v2.4.0
+readonly IMAGE_TAG=v2.5.0
 readonly IMAGE_REPOSITORY="quay.io/helmpack/chart-testing"
 
 main() {

--- a/examples/gke/Dockerfile
+++ b/examples/gke/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/helmpack/chart-testing:v2.4.0
+FROM quay.io/helmpack/chart-testing:v2.5.0
 
 ENV PATH /google-cloud-sdk/bin:$PATH
 ARG CLOUD_SDK_VERSION=221.0.0

--- a/examples/kind/.circleci/config.yml
+++ b/examples/kind/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
 
   lint-charts:
     docker:
-      - image: quay.io/helmpack/chart-testing:v2.4.0
+      - image: quay.io/helmpack/chart-testing:v2.5.0
     steps:
       - checkout
       - run:

--- a/examples/kind/test/e2e-kind.sh
+++ b/examples/kind/test/e2e-kind.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly CT_VERSION=v2.4.0
+readonly CT_VERSION=v2.5.0
 readonly KIND_VERSION=v0.5.1
 readonly CLUSTER_NAME=chart-testing
 readonly K8S_VERSION=v1.15.3

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -33,7 +33,7 @@ func TestFlatten(t *testing.T) {
 	}
 
 	for index, testData := range testDataSlice {
-		t.Run(string(index), func(t *testing.T) {
+		t.Run(fmt.Sprint(index), func(t *testing.T) {
 			actual, err := Flatten(testData.input)
 			assert.Equal(t, testData.expected, actual)
 			if testData.expected != nil {
@@ -61,7 +61,7 @@ func TestCompareVersions(t *testing.T) {
 	}
 
 	for index, testData := range testDataSlice {
-		t.Run(string(index), func(t *testing.T) {
+		t.Run(fmt.Sprint(index), func(t *testing.T) {
 			actual, _ := CompareVersions(testData.oldVersion, testData.newVersion)
 			assert.Equal(t, testData.expected, actual)
 		})
@@ -83,7 +83,7 @@ func TestSanitizeName(t *testing.T) {
 	}
 
 	for index, testData := range testDataSlice {
-		t.Run(string(index), func(t *testing.T) {
+		t.Run(fmt.Sprint(index), func(t *testing.T) {
 			actual := SanitizeName(testData.input, testData.maxLength)
 			fmt.Printf("actual: %s,%d, input: %s,%d\n", actual, len(actual), testData.input, testData.maxLength)
 			assert.Equal(t, testData.expected, actual)
@@ -111,7 +111,7 @@ func TestBreakingChangeAllowed(t *testing.T) {
 	}
 
 	for index, testData := range testDataSlice {
-		t.Run(string(index), func(t *testing.T) {
+		t.Run(fmt.Sprint(index), func(t *testing.T) {
 			actual, _ := BreakingChangeAllowed(testData.left, testData.right)
 			assert.Equal(t, testData.breaking, actual, fmt.Sprintf("input: %s,%s\n", testData.left, testData.right))
 		})

--- a/tag.sh
+++ b/tag.sh
@@ -98,7 +98,7 @@ main() {
     pushd "$SCRIPT_DIR" > /dev/null
 
     git fetch "$remote"
-    git tag -a -m "Release $tag" "$tag" "$remote/master" "${force[@]}"
+    git tag -a -m "Release $tag" "$tag" "$remote/dev-v2" "${force[@]}"
 
     if [[ -z "$skip_push" ]]; then
         git push "$remote" "refs/tags/$tag" "${force[@]}"


### PR DESCRIPTION

**What this PR does / why we need it**:
last chart-testing release for helm v2, that contains the last helm v2 bump to use the final helm v2 (2.17.0) which drops the stable repo from the initialization (which was redirected to another URL)


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
