### PR TITLE
adding option to only show logs + events on failure (#134)

### DIFF
--- a/ct/cmd/install.go
+++ b/ct/cmd/install.go
@@ -77,6 +77,9 @@ func addInstallFlags(flags *flag.FlagSet) {
 	flags.String("release-label", "app.kubernetes.io/instance", heredoc.Doc(`
 		The label to be used as a selector when inspecting resources created by charts.
 		This is only used if namespace is specified`))
+	flags.Bool("log-failed-only", false, heredoc.Doc(`
+		Display logs, descriptions, and events for only failed installations, upgrades,
+		and tests`))
 }
 
 func install(cmd *cobra.Command, args []string) error {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -65,6 +65,7 @@ type Configuration struct {
 	Namespace             string   `mapstructure:"namespace"`
 	ReleaseLabel          string   `mapstructure:"release-label"`
 	ExcludeDeprecated     bool     `mapstructure:"exclude-deprecated"`
+	LogFailedOnly         bool     `mapstructure:"log-failed-only"`
 }
 
 func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*Configuration, error) {


### PR DESCRIPTION
Closes #134.

Adds a new flag for install and lint-and-install called `--log-failed-only`. When applied, logs, events, and descriptions will only be logged when the installation/upgrade/tests fail. This will help prevent overly verbose output in the event users are trying to troubleshoot failures.

Signed-off-by: Austin Dewey <deweya964@gmail.com>
