### PR TITLE
chart_schema.yaml - dependency.version should not be required

### DIFF
--- a/etc/chart_schema.yaml
+++ b/etc/chart_schema.yaml
@@ -24,7 +24,7 @@ maintainer:
 ---
 dependency:
   name: str()
-  version: str()
+  version: str(required=False)
   repository: str(required=False)
   condition: str(required=False)
   tags: list(str(), required=False)


### PR DESCRIPTION
Signed-off-by: Tamal Saha <tamal@appscode.com>

<!--
Thank you for contributing to helm/chart-testing.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

when using a local chart, version field is not required.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Similar to https://github.com/helm/chart-testing/pull/300