### PR TITLE
Add arm64 builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: ci
 on:
   push:
     branches:
-      - '*'
+      - 'main'
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,6 +51,12 @@ jobs:
           go mod tidy
           git diff --exit-code
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Build
         run: |
           set -o nounset

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,12 @@ jobs:
           go mod tidy
           git diff --exit-code
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Login to registry
         uses: docker/login-action@v1
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,6 +35,7 @@ snapshot:
   name_template: "{{ .Tag }}-next"
 dockers:
   - skip_push: false
+    use_buildx: true
     dockerfile: Dockerfile
     image_templates:
       - quay.io/helmpack/chart-testing:{{ .Tag }}-amd64
@@ -54,6 +55,8 @@ dockers:
       - etc/chart_schema.yaml
       - etc/lintconf.yaml
   - skip_push: false
+    goarch: arm64
+    use_buildx: true
     dockerfile: Dockerfile
     image_templates:
       - quay.io/helmpack/chart-testing:{{ .Tag }}-arm64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,14 +34,13 @@ checksum:
 snapshot:
   name_template: "{{ .Tag }}-next"
 dockers:
-  - goos: linux
-    goarch: amd64
-    skip_push: false
+  - skip_push: false
     dockerfile: Dockerfile
     image_templates:
-      - quay.io/helmpack/chart-testing:{{ .Tag }}
-      - quay.io/helmpack/chart-testing:latest
+      - quay.io/helmpack/chart-testing:{{ .Tag }}-amd64
+      - quay.io/helmpack/chart-testing:latest-amd64
     build_flag_templates:
+      - --platform=linux/amd64
       - --label=org.opencontainers.image.version={{ .Version }}
       - --label=org.opencontainers.image.revision={{ .Commit }}
       - --label=org.opencontainers.image.title={{ .ProjectName }}
@@ -54,3 +53,31 @@ dockers:
     extra_files:
       - etc/chart_schema.yaml
       - etc/lintconf.yaml
+  - skip_push: false
+    dockerfile: Dockerfile
+    image_templates:
+      - quay.io/helmpack/chart-testing:{{ .Tag }}-arm64
+      - quay.io/helmpack/chart-testing:latest-arm64
+    build_flag_templates:
+      - --platform=linux/arm64
+      - --label=org.opencontainers.image.version={{ .Version }}
+      - --label=org.opencontainers.image.revision={{ .Commit }}
+      - --label=org.opencontainers.image.title={{ .ProjectName }}
+      - --label=org.opencontainers.image.created={{ .Date }}
+      - --label=org.opencontainers.image.description=ct - The chart testing tool
+      - --label=org.opencontainers.image.vendor=Helm
+      - --label=org.opencontainers.image.licenses=Apache-2.0
+      - --label=org.opencontainers.image.source=https://github.com/helm/chart-testing
+      - --label=org.opencontainers.image.authors=The Helm Authors
+    extra_files:
+      - etc/chart_schema.yaml
+      - etc/lintconf.yaml
+docker_manifests:
+- name_template: quay.io/helmpack/chart-testing:latest
+  image_templates:
+  - quay.io/tauerbec/chart-testing:latest-amd64
+  - quay.io/tauerbec/chart-testing:latest-arm64
+- name_template: quay.io/helmpack/chart-testing:{{ .Tag }}
+  image_templates:
+  - quay.io/tauerbec/chart-testing:{{ .Tag }}-amd64
+  - quay.io/tauerbec/chart-testing:{{ .Tag }}-arm64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -75,9 +75,9 @@ dockers:
 docker_manifests:
 - name_template: quay.io/helmpack/chart-testing:latest
   image_templates:
-  - quay.io/tauerbec/chart-testing:latest-amd64
-  - quay.io/tauerbec/chart-testing:latest-arm64
+  - quay.io/helmpack/chart-testing:latest-amd64
+  - quay.io/helmpack/chart-testing:latest-arm64
 - name_template: quay.io/helmpack/chart-testing:{{ .Tag }}
   image_templates:
-  - quay.io/tauerbec/chart-testing:{{ .Tag }}-amd64
-  - quay.io/tauerbec/chart-testing:{{ .Tag }}-arm64
+  - quay.io/helmpack/chart-testing:{{ .Tag }}-amd64
+  - quay.io/helmpack/chart-testing:{{ .Tag }}-arm64


### PR DESCRIPTION
Signed-off-by: Tyler Auerbeck <tauerbec@redhat.com>

**What this PR does / why we need it**:
This PR adds the building and publishing of arm64 images to quay when a release is published.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #342 

**Special notes for your reviewer**:

This PR adds the publishing of arm64 images as well as amd64 images when a release is published. Because the same `goreleaser` functionality is used in the `ci` workflow, we needed to add the buildx and qemu actions there as well.

When a release is cut, there will now be a few images pushed to quay. For example, given a release of v3.4.5, you would end up with:

- chart-testing:latest-amd64
- chart-testing:latest-arm64
- chart-testing:v3.4.5-amd64
- chart-testing:v3.4.5-arm64
- chart-testing:v3.4.5
- chart-testing:latest

The last two would be the ones that would be useful to users and would direct them to the appropriate arch (and their manifests would just reference the underlying versions). Just wanted to call this out so it wasn't a surprise when this started to happen. 
