### PR TITLE
Set a request timeout on kubectl commands

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -263,7 +263,7 @@ func NewTesting(config config.Configuration, extraSetArgs string) (Testing, erro
 		config:           config,
 		helm:             tool.NewHelm(procExec, extraArgs, strings.Fields(extraSetArgs)),
 		git:              tool.NewGit(procExec),
-		kubectl:          tool.NewKubectl(procExec),
+		kubectl:          tool.NewKubectl(procExec, config.KubectlTimeout),
 		linter:           tool.NewLinter(procExec),
 		cmdExecutor:      tool.NewCmdTemplateExecutor(procExec),
 		accountValidator: tool.AccountValidator{},

--- a/pkg/chart/integration_test.go
+++ b/pkg/chart/integration_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/helm/chart-testing/v3/pkg/config"
 	"github.com/helm/chart-testing/v3/pkg/exec"
@@ -41,7 +42,7 @@ func newTestingHelmIntegration(cfg config.Configuration, extraSetArgs string) Te
 		accountValidator: fakeAccountValidator{},
 		linter:           fakeMockLinter,
 		helm:             tool.NewHelm(procExec, extraArgs, strings.Fields(extraSetArgs)),
-		kubectl:          tool.NewKubectl(procExec),
+		kubectl:          tool.NewKubectl(procExec, 30*time.Second),
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/mitchellh/go-homedir"
 
@@ -41,35 +42,38 @@ var (
 )
 
 type Configuration struct {
-	Remote                  string   `mapstructure:"remote"`
-	TargetBranch            string   `mapstructure:"target-branch"`
-	Since                   string   `mapstructure:"since"`
-	BuildId                 string   `mapstructure:"build-id"`
-	LintConf                string   `mapstructure:"lint-conf"`
-	ChartYamlSchema         string   `mapstructure:"chart-yaml-schema"`
-	ValidateMaintainers     bool     `mapstructure:"validate-maintainers"`
-	ValidateChartSchema     bool     `mapstructure:"validate-chart-schema"`
-	ValidateYaml            bool     `mapstructure:"validate-yaml"`
-	AdditionalCommands      []string `mapstructure:"additional-commands"`
-	CheckVersionIncrement   bool     `mapstructure:"check-version-increment"`
-	ProcessAllCharts        bool     `mapstructure:"all"`
-	Charts                  []string `mapstructure:"charts"`
-	ChartRepos              []string `mapstructure:"chart-repos"`
-	ChartDirs               []string `mapstructure:"chart-dirs"`
-	ExcludedCharts          []string `mapstructure:"excluded-charts"`
-	HelmExtraArgs           string   `mapstructure:"helm-extra-args"`
-	HelmRepoExtraArgs       []string `mapstructure:"helm-repo-extra-args"`
-	HelmDependencyExtraArgs []string `mapstructure:"helm-dependency-extra-args"`
-	Debug                   bool     `mapstructure:"debug"`
-	Upgrade                 bool     `mapstructure:"upgrade"`
-	SkipMissingValues       bool     `mapstructure:"skip-missing-values"`
-	Namespace               string   `mapstructure:"namespace"`
-	ReleaseLabel            string   `mapstructure:"release-label"`
-	ExcludeDeprecated       bool     `mapstructure:"exclude-deprecated"`
+	Remote                  string        `mapstructure:"remote"`
+	TargetBranch            string        `mapstructure:"target-branch"`
+	Since                   string        `mapstructure:"since"`
+	BuildId                 string        `mapstructure:"build-id"`
+	LintConf                string        `mapstructure:"lint-conf"`
+	ChartYamlSchema         string        `mapstructure:"chart-yaml-schema"`
+	ValidateMaintainers     bool          `mapstructure:"validate-maintainers"`
+	ValidateChartSchema     bool          `mapstructure:"validate-chart-schema"`
+	ValidateYaml            bool          `mapstructure:"validate-yaml"`
+	AdditionalCommands      []string      `mapstructure:"additional-commands"`
+	CheckVersionIncrement   bool          `mapstructure:"check-version-increment"`
+	ProcessAllCharts        bool          `mapstructure:"all"`
+	Charts                  []string      `mapstructure:"charts"`
+	ChartRepos              []string      `mapstructure:"chart-repos"`
+	ChartDirs               []string      `mapstructure:"chart-dirs"`
+	ExcludedCharts          []string      `mapstructure:"excluded-charts"`
+	HelmExtraArgs           string        `mapstructure:"helm-extra-args"`
+	HelmRepoExtraArgs       []string      `mapstructure:"helm-repo-extra-args"`
+	HelmDependencyExtraArgs []string      `mapstructure:"helm-dependency-extra-args"`
+	Debug                   bool          `mapstructure:"debug"`
+	Upgrade                 bool          `mapstructure:"upgrade"`
+	SkipMissingValues       bool          `mapstructure:"skip-missing-values"`
+	Namespace               string        `mapstructure:"namespace"`
+	ReleaseLabel            string        `mapstructure:"release-label"`
+	ExcludeDeprecated       bool          `mapstructure:"exclude-deprecated"`
+	KubectlTimeout          time.Duration `mapstructure:"kubectl-timeout"`
 }
 
 func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*Configuration, error) {
 	v := viper.New()
+
+	v.SetDefault("kubectl-timeout", time.Duration(30*time.Second))
 
 	cmd.Flags().VisitAll(func(flag *flag.Flag) {
 		flagName := flag.Name

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -57,6 +58,7 @@ func loadAndAssertConfigFromFile(t *testing.T, configFile string) {
 	require.Equal(t, "default", cfg.Namespace)
 	require.Equal(t, "release", cfg.ReleaseLabel)
 	require.Equal(t, true, cfg.ExcludeDeprecated)
+	require.Equal(t, 120*time.Second, cfg.KubectlTimeout)
 }
 
 func Test_findConfigFile(t *testing.T) {

--- a/pkg/config/test_config.json
+++ b/pkg/config/test_config.json
@@ -29,5 +29,6 @@
     "skip-missing-values": true,
     "namespace": "default",
     "release-label": "release",
-    "exclude-deprecated": true
+    "exclude-deprecated": true,
+    "kubectl-timeout": "120s"
 }

--- a/pkg/config/test_config.yaml
+++ b/pkg/config/test_config.yaml
@@ -25,3 +25,4 @@ skip-missing-values: true
 namespace: default
 release-label: release
 exclude-deprecated: true
+kubectl-timeout: 120s


### PR DESCRIPTION

<!--
Thank you for contributing to helm/chart-testing.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

Simple kubectl commands such as get, describe, and logs should return
quickly, but kubectl does not set a timeout on requests by default.

This change sets a 30s timeout by default on such kubectl commands to
ensure that these don't hang forever if the kubernetes API stops
responding, which is quite possible in CI environments where jobs may
cancelled and kubernetes clusters torn down while ct is running.

This timeout value is configurable via the new `kubectl-timeout` option.

**Which issue this PR fixes**

Hopefully closes: #332

**Special notes for your reviewer**:

n/a