### PR TITLE
feat: Aggregate linting errors and added functionality to pass a glob argument

### DIFF
--- a/ct/cmd/install.go
+++ b/ct/cmd/install.go
@@ -40,13 +40,7 @@ func newInstallCmd() *cobra.Command {
 			command will validate that 'helm test' passes for the following upgrade paths:
 
 			* previous chart revision => current chart version (if non-breaking SemVer change)
-			* current chart version => current chart version
-
-			Charts may have multiple custom values files matching the glob pattern
-			'*-values.yaml' in a directory named 'ci' in the root of the chart's
-			directory. The chart is installed and tested for each of these files.
-			If no custom values file is present, the chart is installed and
-			tested with defaults.`),
+			* current chart version => current chart version`),
 		RunE: install,
 	}
 

--- a/ct/cmd/lint.go
+++ b/ct/cmd/lint.go
@@ -37,12 +37,7 @@ func newLintCmd() *cobra.Command {
 			* specific charts (--charts)
 			* all charts (--all)
 
-			in given chart directories.
-
-			Charts may have multiple custom values files matching the glob pattern
-			'*-values.yaml' in a directory named 'ci' in the root of the chart's
-			directory. The chart is linted for each of these files. If no custom
-			values file is present, the chart is linted with defaults.`),
+			in given chart directories.`),
 		RunE: lint,
 	}
 

--- a/ct/cmd/root.go
+++ b/ct/cmd/root.go
@@ -75,6 +75,8 @@ func addCommonFlags(flags *pflag.FlagSet) {
 		Prints the configuration to stderr (caution: setting this may
 		expose sensitive data when helm-repo-extra-args contains passwords)`))
 	flags.Bool("exclude-deprecated", false, "Skip charts that are marked as deprecated")
+	flags.String("values-glob", "ci/*-values.yaml", heredoc.Doc(`
+	Glob pattern to look for values files`))
 }
 
 func addCommonLintAndInstallFlags(flags *pflag.FlagSet) {

--- a/ct/cmd/root.go
+++ b/ct/cmd/root.go
@@ -76,7 +76,7 @@ func addCommonFlags(flags *pflag.FlagSet) {
 		expose sensitive data when helm-repo-extra-args contains passwords)`))
 	flags.Bool("exclude-deprecated", false, "Skip charts that are marked as deprecated")
 	flags.String("values-glob", "ci/*-values.yaml", heredoc.Doc(`
-	Glob pattern to look for values files`))
+	The glob pattern used to search for additional values files in chart directories`))
 }
 
 func addCommonLintAndInstallFlags(flags *pflag.FlagSet) {

--- a/doc/ct_install.md
+++ b/doc/ct_install.md
@@ -16,12 +16,6 @@ command will validate that 'helm test' passes for the following upgrade paths:
 * previous chart revision => current chart version (if non-breaking SemVer change)
 * current chart version => current chart version
 
-Charts may have multiple custom values files matching the glob pattern
-'*-values.yaml' in a directory named 'ci' in the root of the chart's
-directory. The chart is installed and tested for each of these files.
-If no custom values file is present, the chart is installed and
-tested with defaults.
-
 ```
 ct install [flags]
 ```
@@ -69,6 +63,7 @@ ct install [flags]
       --target-branch string           The name of the target branch used to identify changed charts (default "master")
       --upgrade                        Whether to test an in-place upgrade of each chart from its previous revision if the
                                        current version should not introduce a breaking change according to the SemVer spec
+      --values-glob string             The glob pattern used to search for additional values files in chart directories (default "ci/*-values.yaml")
 ```
 
 ### SEE ALSO

--- a/doc/ct_lint.md
+++ b/doc/ct_lint.md
@@ -14,11 +14,6 @@ and maintainer validation on
 
 in given chart directories.
 
-Charts may have multiple custom values files matching the glob pattern
-'*-values.yaml' in a directory named 'ci' in the root of the chart's
-directory. The chart is linted for each of these files. If no custom
-values file is present, the chart is linted with defaults.
-
 ```
 ct lint [flags]
 ```
@@ -67,6 +62,7 @@ ct lint [flags]
       --validate-maintainers           Enable validation of maintainer account names in chart.yml.
                                        Works for GitHub, GitLab, and Bitbucket (default true)
       --validate-yaml                  Enable linting of 'Chart.yaml' and values files (default true)
+      --values-glob string             The glob pattern used to search for additional values files in chart directories (default "ci/*-values.yaml")
 ```
 
 ### SEE ALSO

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -320,6 +320,26 @@ func TestLintYamlValidation(t *testing.T) {
 	runTests(false, 0, 0)
 }
 
+func TestDifferentGlob(t *testing.T) {
+	type testData struct {
+		name     string
+		chartDir string
+		expected []string
+	}
+
+	testCases := []testData{
+		{"test-glob", "testdata/test_glob", []string{"testdata/test_glob/values.other.yaml"}},
+	}
+
+	for _, testData := range testCases {
+		t.Run(testData.name, func(t *testing.T) {
+			chart, err := NewChart(testData.chartDir, "values.*.yaml")
+			assert.Nil(t, err)
+			assert.Equal(t, testData.expected, chart.ciValuesPaths)
+		})
+	}
+}
+
 func TestGenerateInstallConfig(t *testing.T) {
 	type testData struct {
 		name  string
@@ -384,7 +404,7 @@ func TestGenerateInstallConfig(t *testing.T) {
 	}
 }
 
-func TestChart_HasCIValuesFile(t *testing.T) {
+func TestChart_DifferentGlobPattern(t *testing.T) {
 	type testData struct {
 		name     string
 		chart    *Chart

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -404,7 +404,7 @@ func TestGenerateInstallConfig(t *testing.T) {
 	}
 }
 
-func TestChart_DifferentGlobPattern(t *testing.T) {
+func TestChart_HasCIValuesFile(t *testing.T) {
 	type testData struct {
 		name     string
 		chart    *Chart

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -185,7 +185,7 @@ func TestValidateMaintainers(t *testing.T) {
 
 	for _, testData := range testDataSlice {
 		t.Run(testData.name, func(t *testing.T) {
-			chart, err := NewChart(testData.chartDir)
+			chart, err := NewChart(testData.chartDir, "ci/*-values.yaml")
 			assert.Nil(t, err)
 			validationErr := ct.ValidateMaintainers(chart)
 			assert.Equal(t, testData.expected, validationErr == nil)
@@ -217,7 +217,7 @@ func TestLintChartMaintainerValidation(t *testing.T) {
 
 		for _, testData := range testCases {
 			t.Run(testData.name, func(t *testing.T) {
-				chart, err := NewChart(testData.chartDir)
+				chart, err := NewChart(testData.chartDir, "ci/*-values.yaml")
 				assert.Nil(t, err)
 				result := ct.LintChart(chart)
 				assert.Equal(t, testData.expected, result.Error == nil)
@@ -260,7 +260,7 @@ func TestLintChartSchemaValidation(t *testing.T) {
 
 		for _, testData := range testCases {
 			t.Run(testData.name, func(t *testing.T) {
-				chart, err := NewChart(testData.chartDir)
+				chart, err := NewChart(testData.chartDir, "ci/*-values.yaml")
 				assert.Nil(t, err)
 				result := ct.LintChart(chart)
 				assert.Equal(t, testData.expected, result.Error == nil)
@@ -306,7 +306,7 @@ func TestLintYamlValidation(t *testing.T) {
 
 		for _, testData := range testCases {
 			t.Run(testData.name, func(t *testing.T) {
-				chart, err := NewChart(testData.chartDir)
+				chart, err := NewChart(testData.chartDir, "ci/*-values.yaml")
 				assert.Nil(t, err)
 				result := ct.LintChart(chart)
 				assert.Equal(t, testData.expected, result.Error == nil)

--- a/pkg/chart/testdata/test_glob/Chart.yaml
+++ b/pkg/chart/testdata/test_glob/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+appVersion: xoxo
+description: A Helm chart for testing
+name: invalid
+version: 1.2.3
+home: https://github.com/helm/chart-testing
+maintainers:
+  - name: invalid
+  - email: invalid@example.com
+

--- a/pkg/chart/testdata/test_glob/values.other.yaml
+++ b/pkg/chart/testdata/test_glob/values.other.yaml
@@ -1,0 +1,3 @@
+test: abc
+list:
+  - abc

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -65,6 +65,7 @@ type Configuration struct {
 	Namespace             string   `mapstructure:"namespace"`
 	ReleaseLabel          string   `mapstructure:"release-label"`
 	ExcludeDeprecated     bool     `mapstructure:"exclude-deprecated"`
+	ValuesGlob            string   `mapstructure:"values-glob"`
 }
 
 func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*Configuration, error) {


### PR DESCRIPTION
<!--
Thank you for contributing to helm/chart-testing.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
This PR implements two things: 
- The linting errors will now be aggregated in a list and returned at the end, this means that all the errors encountered while linting will show to the user. Instead of encountering an error, exiting immediately and then the user has to run lint multiple times. Also the current error implementation did not allow for linting of multiple values.yaml files. If an error was encountered in the first file, the rest of the values would be skipped.
- The ability to pass a glob pattern to look for values.yaml files, currently this was hardcoded to `ci/*values.yaml`.

**Which issue this PR fixes** 
fixes https://github.com/helm/chart-testing/issues/171

**Special notes for your reviewer**:
Not 100% sure if the `Errors` list I added has any implications for the `ct test` command. Please let me know if this is the case. Thanks!
