### PR TITLE
feat(lint): add yamale and yamllint extra-args flags

### DIFF
--- a/ct/cmd/lint.go
+++ b/ct/cmd/lint.go
@@ -74,6 +74,8 @@ func addLintFlags(flags *flag.FlagSet) {
             Commands will be executed in the same order as provided in the list and will
             be rendered with go template before being executed.
             Example: "helm unittest --helm3 -f tests/*.yaml {{ .Path }}"`))
+	flags.StringSlice("yamale-extra-args", []string{}, "Additional arguments to pass to 'yamale'")
+	flags.StringSlice("yamllint-extra-args", []string{}, "Additional arguments to pass to 'yamllint'")
 }
 
 func lint(cmd *cobra.Command, args []string) error {

--- a/doc/ct_lint-and-install.md
+++ b/doc/ct_lint-and-install.md
@@ -72,6 +72,8 @@ ct lint-and-install [flags]
       --validate-maintainers                 Enable validation of maintainer account names in chart.yml.
                                              Works for GitHub, GitLab, and Bitbucket (default true)
       --validate-yaml                        Enable linting of 'Chart.yaml' and values files (default true)
+      --yamale-extra-args strings            Additional arguments to pass to 'yamale'
+      --yamllint-extra-args strings          Additional arguments to pass to 'yamllint'
 ```
 
 ### SEE ALSO

--- a/doc/ct_lint.md
+++ b/doc/ct_lint.md
@@ -68,6 +68,8 @@ ct lint [flags]
       --validate-maintainers                 Enable validation of maintainer account names in chart.yml.
                                              Works for GitHub, GitLab, and Bitbucket (default true)
       --validate-yaml                        Enable linting of 'Chart.yaml' and values files (default true)
+      --yamale-extra-args strings            Additional arguments to pass to 'yamale'
+      --yamllint-extra-args strings          Additional arguments to pass to 'yamllint'
 ```
 
 ### SEE ALSO

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -130,8 +130,8 @@ type Kubectl interface {
 //
 // Yamale runs `yamale` on the specified file with the specified schema file
 type Linter interface {
-	YamlLint(yamlFile string, configFile string) error
-	Yamale(yamlFile string, schemaFile string) error
+	YamlLint(yamlFile string, configFile string, extraArgs []string) error
+	Yamale(yamlFile string, schemaFile string, extraArgs []string) error
 }
 
 // CmdExecutor is the interface
@@ -445,7 +445,7 @@ func (t *Testing) LintChart(chart *Chart) TestResult {
 	valuesFiles := chart.ValuesFilePathsForCI()
 
 	if t.config.ValidateChartSchema {
-		if err := t.linter.Yamale(chartYaml, t.config.ChartYamlSchema); err != nil {
+		if err := t.linter.Yamale(chartYaml, t.config.ChartYamlSchema, t.config.YamaleExtraArgs); err != nil {
 			result.Error = err
 			return result
 		}
@@ -454,7 +454,7 @@ func (t *Testing) LintChart(chart *Chart) TestResult {
 	if t.config.ValidateYaml {
 		yamlFiles := append([]string{chartYaml, valuesYaml}, valuesFiles...)
 		for _, yamlFile := range yamlFiles {
-			if err := t.linter.YamlLint(yamlFile, t.config.LintConf); err != nil {
+			if err := t.linter.YamlLint(yamlFile, t.config.LintConf, t.config.YamllintExtraArgs); err != nil {
 				result.Error = err
 				return result
 			}

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -83,12 +83,12 @@ type fakeLinter struct {
 	mock.Mock
 }
 
-func (l *fakeLinter) YamlLint(yamlFile, configFile string) error {
-	l.Called(yamlFile, configFile)
+func (l *fakeLinter) YamlLint(yamlFile, configFile string, extraArgs []string) error {
+	l.Called(yamlFile, configFile, extraArgs)
 	return nil
 }
-func (l *fakeLinter) Yamale(yamlFile, schemaFile string) error {
-	l.Called(yamlFile, schemaFile)
+func (l *fakeLinter) Yamale(yamlFile, schemaFile string, extraArgs []string) error {
+	l.Called(yamlFile, schemaFile, extraArgs)
 	return nil
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -71,6 +71,8 @@ type Configuration struct {
 	ExcludeDeprecated       bool          `mapstructure:"exclude-deprecated"`
 	KubectlTimeout          time.Duration `mapstructure:"kubectl-timeout"`
 	PrintLogs               bool          `mapstructure:"print-logs"`
+	YamaleExtraArgs         []string      `mapstructure:"yamale-extra-args"`
+	YamllintExtraArgs       []string      `mapstructure:"yamllint-extra-args"`
 }
 
 func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*Configuration, error) {

--- a/pkg/tool/linter.go
+++ b/pkg/tool/linter.go
@@ -26,10 +26,10 @@ func NewLinter(exec exec.ProcessExecutor) Linter {
 	}
 }
 
-func (l Linter) YamlLint(yamlFile string, configFile string) error {
-	return l.exec.RunProcess("yamllint", "--config-file", configFile, yamlFile)
+func (l Linter) YamlLint(yamlFile string, configFile string, extraArgs []string) error {
+	return l.exec.RunProcess("yamllint", "--config-file", configFile, extraArgs, yamlFile)
 }
 
-func (l Linter) Yamale(yamlFile string, schemaFile string) error {
-	return l.exec.RunProcess("yamale", "--schema", schemaFile, yamlFile)
+func (l Linter) Yamale(yamlFile string, schemaFile string, extraArgs []string) error {
+	return l.exec.RunProcess("yamale", "--schema", schemaFile, extraArgs, yamlFile)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds `--yamllint-extra-args` and `--yamale-extra-args` flags to `ct lint`. Yamllint in particular has options

**Which issue this PR fixes**:

This allows users of `ct` to fix or workaround https://github.com/helm/chart-testing-action/issues/70 by passing `--yamllint-extra-args -f,standard`.

**Special notes for your reviewer**:

The issue with the default `github` formatting with yamllint is github seems to swallow the important information that is output when `yamllint` detects it is running under a github action, as can be seen in https://github.com/helm/chart-testing-action/issues/70. 

If it would be preferable to just hardcode `-f standard` into `ct`, I can issue a PR to do that, too, but being able to fully customize how yamale and yamllint are run might be useful for other situations, too.