### PR TITLE
Adding size labeler as a GH action

### DIFF
--- a/.github/pr-size-labeler.yml
+++ b/.github/pr-size-labeler.yml
@@ -1,0 +1,6 @@
+'size/XS': 9
+'size/S': 29
+'size/M': 99
+'size/L': 499
+'size/XL': 999
+'size/XXL': Infinity

--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Size Labeler"
+on: [pull_request]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: julrocas/pr-size-labeler@v1.0
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        configuration-path: .github/pr-size-labeler.yml


### PR DESCRIPTION
The current automation for sizing PRs is run as a bot and
needs to be retired. This action with this configuration
will size PRs in the same manner the bot has.
<!--
Thank you for contributing to helm/chart-testing.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**: The PR sizing bot is going away and this PR provides a GitHub action that does the same thing.

**Special notes for your reviewer**: N/A
