### PR TITLE
fix: add unit to extra arg help message

### DIFF
--- a/ct/cmd/install.go
+++ b/ct/cmd/install.go
@@ -63,7 +63,7 @@ func addInstallFlags(flags *flag.FlagSet) {
 		the ID of a pull request. If not specified, the name of the chart is used`))
 	flags.String("helm-extra-args", "", heredoc.Doc(`
 		Additional arguments for Helm. Must be passed as a single quoted string
-		(e.g. "--timeout 500"`))
+		(e.g. "--timeout 500s"`))
 	flags.Bool("upgrade", false, heredoc.Doc(`
 		Whether to test an in-place upgrade of each chart from its previous revision if the
 		current version should not introduce a breaking change according to the SemVer spec`))

--- a/doc/ct_install.md
+++ b/doc/ct_install.md
@@ -49,7 +49,7 @@ ct install [flags]
       --excluded-charts strings        Charts that should be skipped. May be specified multiple times
                                        or separate values with commas
       --helm-extra-args string         Additional arguments for Helm. Must be passed as a single quoted string
-                                       (e.g. "--timeout 500"
+                                       (e.g. "--timeout 500s"
       --helm-repo-extra-args strings   Additional arguments for the 'helm repo add' command to be
                                        specified on a per-repo basis with an equals sign as delimiter
                                        (e.g. 'myrepo=--username test --password secret'). May be specified

--- a/doc/ct_lint-and-install.md
+++ b/doc/ct_lint-and-install.md
@@ -41,7 +41,7 @@ ct lint-and-install [flags]
       --excluded-charts strings        Charts that should be skipped. May be specified multiple times
                                        or separate values with commas
       --helm-extra-args string         Additional arguments for Helm. Must be passed as a single quoted string
-                                       (e.g. "--timeout 500"
+                                       (e.g. "--timeout 500s"
       --helm-repo-extra-args strings   Additional arguments for the 'helm repo add' command to be
                                        specified on a per-repo basis with an equals sign as delimiter
                                        (e.g. 'myrepo=--username test --password secret'). May be specified


### PR DESCRIPTION
<!--
Thank you for contributing to helm/chart-testing.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

Add a unit (s == seconds) to the `--helm-extra-args` help message.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

The help message for the `--helm-extra-args` config used an example without units,
which caused to fail the next chart-testing run if just copy-pasted.

```
Error: invalid argument "500" for "--timeout" flag: time: missing unit in duration "500"
Error deleting Helm release: Error waiting for process: exit status 1
```

**Special notes for your reviewer**:

Might be related to newer go versions ? https://github.com/kubernetes/kubernetes/issues/40783