### PR TITLE
docs(README): use the host network in docker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ If you have a chart in current directory and ct installed on the host then you c
 
 With docker it works with:
 
-    docker run -it --workdir=/data --volume ~/.kube/config:/root/.kube/config:ro --volume $(pwd):/data quay.io/helmpack/chart-testing:v3.5.0 ct install --chart-dirs . --charts .
+    docker run -it --network host --workdir=/data --volume ~/.kube/config:/root/.kube/config:ro --volume $(pwd):/data quay.io/helmpack/chart-testing:v3.5.0 ct install --chart-dirs . --charts .
 
 Notice that `workdir` param is important and must be the same as volume mounted.
 


### PR DESCRIPTION
**What this PR does / why we need it**: The docker container will use `host` network with no network isolation. That way, `ct install` can connect to k8s cluster running on host's machine.

**Which issue this PR fixes**: fixes #394