### PR TITLE
FIX: it should upgrade to new version instead of the old one

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -628,7 +628,7 @@ func (t *Testing) doUpgrade(oldChart, newChart *Chart, oldChartMustPass bool) er
 				return nil
 			}
 
-			if err := t.helm.Upgrade(oldChart.Path(), namespace, release); err != nil {
+			if err := t.helm.Upgrade(newChart.Path(), namespace, release); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When testing the upgrade we should actually install the new version

Old behaviour (installing the same version, not catching the issue with selectors)
```
Testing upgrades of chart 'nri-prometheus => (version: "2.1.2", path: "charts/nri-prometheus")' relative to previous revision 'nri-prometheus => (version: "2.1.1", path: "ct_previous_revision2130172757/charts/nri-prometheus")'...
[...]
>>> helm install nri-prometheus-y2dumyevqw ct_previous_revision2130172757/charts/nri-prometheus --namespace ct --wait --values ct_previous_revision2130172757/charts/nri-prometheus/ci/test-lowdatamode-values.yaml
>>> helm upgrade nri-prometheus-y2dumyevqw ct_previous_revision2130172757/charts/nri-prometheus --namespace ct --reuse-values --wait
```

New Behaviour (installing the new version, catching the issue)
```
Testing upgrades of chart 'nri-prometheus => (version: "2.1.2", path: "charts/nri-prometheus")' relative to previous revision 'nri-prometheus => (version: "2.1.1", path: "ct_previous_revision78831704/charts/nri-prometheus")'...
[...]
>>> helm install nri-prometheus-avhvhn5q0a ct_previous_revision78831704/charts/nri-prometheus --namespace ct --wait --values ct_previous_revision78831704/charts/nri-prometheus/ci/test-lowdatamode-values.yaml
>>> helm upgrade nri-prometheus-avhvhn5q0a charts/nri-prometheus --namespace ct --reuse-values --wait
Error: UPGRADE FAILED: cannot patch "nri-prometheus" with kind Deployment: Deployment.apps "nri-prometheus" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app.kubernetes.io/name":"nri-prometheus"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable

```

**Which issue this PR fixes** 

Fix https://github.com/helm/chart-testing/issues/433

**Special notes for your reviewer**:

Please let me know if I am misunderstanding the feature or the code (it is a vely likely possibility 😄 )