### PR TITLE
fixes for kind config

### DIFF
--- a/examples/kind/test/e2e-kind.sh
+++ b/examples/kind/test/e2e-kind.sh
@@ -41,7 +41,8 @@ create_kind_cluster() {
     kind create cluster --name "$CLUSTER_NAME" --config test/kind-config.yaml --image "kindest/node:$K8S_VERSION" --wait 60s
 
     echo 'Copying kubeconfig to container...'
-    docker cp /root/.kube/config ct:/root/.kube/config
+    docker_exec mkdir /root/.kube
+    docker cp /root/.kube/kind-config ct:/root/.kube/config
 
     docker_exec kubectl cluster-info
     echo

--- a/examples/kind/test/kind-config.yaml
+++ b/examples/kind/test/kind-config.yaml
@@ -1,5 +1,5 @@
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
   - role: worker


### PR DESCRIPTION
Signed-off-by: Simon Harrison <simon.harrison@mediakind.com>

<!--
Thank you for contributing to helm/chart-testing.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
- The `v1alpha3` API was deprecated in KIND 0.9.0
  - https://github.com/kubernetes-sigs/kind/releases/tag/v0.9.0 
- The generated kube-config is now named `kind-config`, not `config`
- The docker cp fails because `/root/.kube` does not exist in the `ct` container 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
