### PR TITLE
feat(helm): Add support for OCI chart repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Notice that if no config file is specified, then `ct.yaml` (or any of the suppor
 #### Using private chart repositories
 
 When adding chart-repos you can specify additional arguments for the `helm repo add` command using `helm-repo-extra-args` on a per-repo basis.
+You can also specify OCI registries which will be added using the `helm registry login` command, they also support the `helm-repo-extra-args` for authentication.
 This could for example be used to authenticate a private chart repository.
 
 `config.yaml`:
@@ -140,6 +141,7 @@ chart-repos:
   - incubator=https://incubator.io
   - basic-auth=https://private.com
   - ssl-repo=https://self-signed.ca
+  - oci-registry=oci://nice-oci-registry.pt
 helm-repo-extra-args:
   - ssl-repo=--ca-file ./my-ca.crt
 ```

--- a/pkg/tool/helm.go
+++ b/pkg/tool/helm.go
@@ -16,6 +16,7 @@ package tool
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/helm/chart-testing/v3/pkg/exec"
 )
@@ -35,6 +36,13 @@ func NewHelm(exec exec.ProcessExecutor, extraArgs []string, extraSetArgs []strin
 }
 
 func (h Helm) AddRepo(name string, url string, extraArgs []string) error {
+	const ociPrefix string = "oci://"
+
+	if strings.HasPrefix(url, ociPrefix) {
+		registryDomain := url[len(ociPrefix):]
+		return h.exec.RunProcess("helm", "registry", "login", registryDomain, extraArgs)
+	}
+
 	return h.exec.RunProcess("helm", "repo", "add", name, url, extraArgs)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Since Helm 3.8 the support of OCI registries is no longer experimental and is enabled by default, this means that more and more people will be using registries to store charts. In order to support this type of repository, a small change is needed because OCI registries can't be added like "regular repositories", and need to use a different command "helm registry login".

Therefore, and since it was [already agreed](https://helm.sh/blog/storing-charts-in-oci/) that OCI repositories should start the URL with "oci://" this PR uses the prefix of the repository URL to select the right command to be able to add these type of repositories.

**Special notes for your reviewer**: I didn't added any automation test because didn't find any similar to what already was done, I tested this locally using a registry of mine.

Signed-off-by: João Fernandes <jcsf_1995@hotmail.com>