### PR TITLE
Fix integration tests for upgrade flag

### DIFF
--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -184,13 +184,15 @@ func TestReadAllChartDirectories(t *testing.T) {
 		"test_charts/bar",
 		"test_charts/must-pass-upgrade-install",
 		"test_charts/mutating-deployment-selector",
+		"test_charts/simple-deployment",
+		"test_charts/simple-deployment-different-selector",
 		"test_charts/mutating-sfs-volumeclaim",
 		"test_chart_at_root",
 	}
 	for _, chart := range actual {
 		assert.Contains(t, expected, chart)
 	}
-	assert.Len(t, actual, 6)
+	assert.Len(t, actual, 8)
 	assert.Nil(t, err)
 }
 

--- a/pkg/chart/integration_test.go
+++ b/pkg/chart/integration_test.go
@@ -141,6 +141,12 @@ func TestUpgradeChart(t *testing.T) {
 			"test_charts/mutating-sfs-volumeclaim",
 			processError,
 		},
+		{
+			"change immutable deployment.spec.selector.matchLabels field",
+			"test_charts/simple-deployment",
+			"test_charts/simple-deployment-different-selector",
+			processError,
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/chart/test_charts/mutating-deployment-selector/templates/deployment.yaml
+++ b/pkg/chart/test_charts/mutating-deployment-selector/templates/deployment.yaml
@@ -12,6 +12,11 @@ metadata:
     revision: {{ .Release.Revision | quote }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "nginx.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      revision: {{ .Release.Revision | quote }}
   template:
     metadata:
       labels:

--- a/pkg/chart/test_charts/simple-deployment-different-selector/Chart.yaml
+++ b/pkg/chart/test_charts/simple-deployment-different-selector/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: nginx
+version: 0.1.0

--- a/pkg/chart/test_charts/simple-deployment-different-selector/README.md
+++ b/pkg/chart/test_charts/simple-deployment-different-selector/README.md
@@ -1,0 +1,4 @@
+Simple chart with a Deployment having a different selector.
+
+The integration test will install first simple-deployment and then try to upgrade
+to simple-deployment-different-selector failing as expected

--- a/pkg/chart/test_charts/simple-deployment-different-selector/templates/_helpers.tpl
+++ b/pkg/chart/test_charts/simple-deployment-different-selector/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nginx.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "nginx.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nginx.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/pkg/chart/test_charts/simple-deployment-different-selector/templates/deployment.yaml
+++ b/pkg/chart/test_charts/simple-deployment-different-selector/templates/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "nginx.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "nginx.name" . }}
+    helm.sh/chart: {{ include "nginx.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "nginx.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      extra: label
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "nginx.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        extra: label
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP

--- a/pkg/chart/test_charts/simple-deployment-different-selector/values.yaml
+++ b/pkg/chart/test_charts/simple-deployment-different-selector/values.yaml
@@ -1,0 +1,11 @@
+# Default values for nginx.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: nginx
+  tag: stable
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""

--- a/pkg/chart/test_charts/simple-deployment/Chart.yaml
+++ b/pkg/chart/test_charts/simple-deployment/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: nginx
+version: 0.1.0

--- a/pkg/chart/test_charts/simple-deployment/README.md
+++ b/pkg/chart/test_charts/simple-deployment/README.md
@@ -1,0 +1,4 @@
+Simple chart with a Deployment.
+
+The integration test will install first simple-deployment and then try to upgrade
+to simple-deployment-different-selector failing as expected

--- a/pkg/chart/test_charts/simple-deployment/templates/_helpers.tpl
+++ b/pkg/chart/test_charts/simple-deployment/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nginx.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "nginx.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nginx.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/pkg/chart/test_charts/simple-deployment/templates/deployment.yaml
+++ b/pkg/chart/test_charts/simple-deployment/templates/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "nginx.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "nginx.name" . }}
+    helm.sh/chart: {{ include "nginx.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "nginx.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "nginx.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP

--- a/pkg/chart/test_charts/simple-deployment/values.yaml
+++ b/pkg/chart/test_charts/simple-deployment/values.yaml
@@ -1,0 +1,11 @@
+# Default values for nginx.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: nginx
+  tag: stable
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""


### PR DESCRIPTION
**What this PR does / why we need it**:
It fixes:
 - the integration test "change immutable deployment.spec.selector field". Since the selector was missing from the manifest the upgrade tests was always failing causing a false positive. This is because the required fields changed in `apps/v1` and selector were not added by https://github.com/helm/chart-testing/pull/205

The error always showing before the upgrade was:
```
missing required field "selector" in io.k8s.api.apps.v1.DeploymentSpec
```
It adds:
-  integration tests to avoid regression of https://github.com/helm/chart-testing/pull/434. Basically two simple deployment manifests with the second one adding a different selector. The tests differ from the other one since the different selector belongs to a different chart/chartVersion

