### PR TITLE
Upgrade go1.19, helm update and add golangci-lint job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,3 +75,17 @@ jobs:
 
           echo "Building snapshot..."
           ./build.sh
+
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
+      - uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a # v3
+        with:
+          go-version-file: './go.mod'
+          check-latest: true
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc # v3
+        with:
+          version: v1.48.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
       - name: checkout
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.1
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
         with:
           fetch-depth: 0
 
@@ -22,7 +22,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v3.3.0
         with:
-          go-version: '1.18'
+          go-version-file: './go.mod'
           check-latest: true
 
       - uses: azure/setup-helm@b5b231a831f96336bbfeccc1329990f0005c5bb1 # v3.3
@@ -40,15 +40,14 @@ jobs:
       - name: Install syft
         uses: anchore/sbom-action/download-syft@b5042e9d19d8b32849779bfe17673ff84aec702d # v0.12.0
 
+      - name: Create k8s Kind Cluster
+        uses: helm/kind-action@d08cf6ff1575077dee99962540d77ce91c62387d # v1.3.0
+
       - name: Install tools
         run: |
           curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
           chmod +x ./kubectl
           sudo mv ./kubectl /usr/local/bin/kubectl
-
-          curl -fsSLo kind "https://github.com/kubernetes-sigs/kind/releases/download/v0.14.0/kind-linux-amd64"
-          chmod +x kind
-          sudo mv kind /usr/local/bin/kind
 
           ./setup.sh
 
@@ -64,10 +63,10 @@ jobs:
           git diff --exit-code
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@8b122486cedac8393e77aa9734c3528886e4a1a8 # v1.2.0
+        uses: docker/setup-qemu-action@8b122486cedac8393e77aa9734c3528886e4a1a8 # v2.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6 # v1.6.0
+        uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6 # v2.0.0
 
       - name: Build
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,8 +40,10 @@ jobs:
       - name: Install syft
         uses: anchore/sbom-action/download-syft@b5042e9d19d8b32849779bfe17673ff84aec702d # v0.12.0
 
-      - name: Create k8s Kind Cluster
+      - name: Install k8s Kind
         uses: helm/kind-action@d08cf6ff1575077dee99962540d77ce91c62387d # v1.3.0
+        with:
+          install_only: true
 
       - name: Install tools
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v3.3.0
         with:
-          go-version: '1.18'
+          go-version-file: './go.mod'
           check-latest: true
 
       - name: Install GoReleaser
@@ -53,13 +53,13 @@ jobs:
           git diff --exit-code
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@8b122486cedac8393e77aa9734c3528886e4a1a8 # v1.2.0
+        uses: docker/setup-qemu-action@8b122486cedac8393e77aa9734c3528886e4a1a8 # v2.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6 # v1.6.0
+        uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6 # v2.0.0
 
       - name: Login to registry
-        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # v1.14.1
+        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # v2.0.0
         with:
           registry: quay.io
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,31 @@
+linters:
+  enable:
+  - asciicheck
+  - deadcode
+  - depguard
+  - errcheck
+  - errorlint
+  - gofmt
+  - goimports
+  - gosec
+  - gocritic
+  - importas
+  - prealloc
+  - revive
+  - misspell
+  - stylecheck
+  - unconvert
+  - whitespace
+output:
+  uniq-by-line: false
+issues:
+  exclude-rules:
+  - path: _test\.go
+    linters:
+    - errcheck
+    - gosec
+  max-issues-per-linter: 0
+  max-same-issues: 0
+run:
+  issues-exit-code: 1
+  timeout: 10m

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$kubectl
     mv kubectl /usr/local/bin/
 
 # Install Helm
-ARG helm_version=v3.9.2
+ARG helm_version=v3.9.3
 LABEL helm_version=$helm_version
 RUN targetArch=$(echo $TARGETPLATFORM | cut -f2 -d '/') \
     && if [ ${targetArch} = "amd64" ]; then \

--- a/ct/cmd/install.go
+++ b/ct/cmd/install.go
@@ -91,7 +91,7 @@ func install(cmd *cobra.Command, args []string) error {
 	}
 	configuration, err := config.LoadConfiguration(cfgFile, cmd, printConfig)
 	if err != nil {
-		return fmt.Errorf("Error loading configuration: %s", err)
+		return fmt.Errorf("failed loading configuration: %w", err)
 	}
 
 	extraSetArgs, err := cmd.Flags().GetString("helm-extra-set-args")
@@ -106,7 +106,7 @@ func install(cmd *cobra.Command, args []string) error {
 	testing.PrintResults(results)
 
 	if err != nil {
-		return fmt.Errorf("Error installing charts: %s", err)
+		return fmt.Errorf("failed installing charts: %w", err)
 	}
 
 	fmt.Println("All charts installed successfully")

--- a/ct/cmd/lint.go
+++ b/ct/cmd/lint.go
@@ -85,7 +85,7 @@ func lint(cmd *cobra.Command, args []string) error {
 	}
 	configuration, err := config.LoadConfiguration(cfgFile, cmd, printConfig)
 	if err != nil {
-		return fmt.Errorf("Error loading configuration: %s", err)
+		return fmt.Errorf("failed loading configuration: %w", err)
 	}
 
 	emptyExtraSetArgs := ""
@@ -97,7 +97,7 @@ func lint(cmd *cobra.Command, args []string) error {
 	testing.PrintResults(results)
 
 	if err != nil {
-		return fmt.Errorf("Error linting charts: %s", err)
+		return fmt.Errorf("failed linting charts: %w", err)
 	}
 
 	fmt.Println("All charts linted successfully")

--- a/ct/cmd/lintAndInstall.go
+++ b/ct/cmd/lintAndInstall.go
@@ -48,7 +48,7 @@ func lintAndInstall(cmd *cobra.Command, args []string) error {
 	}
 	configuration, err := config.LoadConfiguration(cfgFile, cmd, printConfig)
 	if err != nil {
-		return fmt.Errorf("Error loading configuration: %s", err)
+		return fmt.Errorf("failed loading configuration: %w", err)
 	}
 
 	extraSetArgs, err := cmd.Flags().GetString("helm-extra-set-args")
@@ -63,7 +63,7 @@ func lintAndInstall(cmd *cobra.Command, args []string) error {
 	testing.PrintResults(results)
 
 	if err != nil {
-		return fmt.Errorf("Error linting and installing charts: %s", err)
+		return fmt.Errorf("failed linting and installing charts: %w", err)
 	}
 
 	fmt.Println("All charts linted and installed successfully")

--- a/ct/cmd/listChanged.go
+++ b/ct/cmd/listChanged.go
@@ -47,7 +47,7 @@ func listChanged(cmd *cobra.Command, args []string) error {
 	}
 	configuration, err := config.LoadConfiguration(cfgFile, cmd, printConfig)
 	if err != nil {
-		return fmt.Errorf("Error loading configuration: %s", err)
+		return fmt.Errorf("failed loading configuration: %w", err)
 	}
 
 	emptyExtraSetArgs := ""
@@ -63,5 +63,6 @@ func listChanged(cmd *cobra.Command, args []string) error {
 	for _, dir := range chartDirs {
 		fmt.Println(dir)
 	}
+
 	return nil
 }

--- a/e2e-kind.sh
+++ b/e2e-kind.sh
@@ -7,7 +7,7 @@ set -o pipefail
 CLUSTER_NAME=chart-testing
 readonly CLUSTER_NAME
 
-K8S_VERSION=v1.21.2
+K8S_VERSION=v1.22.9
 readonly K8S_VERSION
 
 create_kind_cluster() {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/helm/chart-testing/v3
 
-go 1.18
+go 1.19
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -168,7 +168,6 @@ github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCko
 github.com/pelletier/go-toml/v2 v2.0.5 h1:ipoSadvV8oGUjnUbMub59IDPPwfxF694nG/jwbMiyQg=
 github.com/pelletier/go-toml/v2 v2.0.5/go.mod h1:OMHamSCAODeSsVrwwvcJOaoN0LIUIaFVNZzmWyNfXas=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -15,6 +15,7 @@
 package chart
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -696,7 +697,7 @@ func (t *Testing) FindChartDirsToBeProcessed() ([]string, error) {
 func (t *Testing) computeMergeBase() (string, error) {
 	err := t.git.ValidateRepository()
 	if err != nil {
-		return "", fmt.Errorf("must be in a git repository")
+		return "", errors.New("must be in a git repository")
 	}
 	return t.git.MergeBase(fmt.Sprintf("%s/%s", t.config.Remote, t.config.TargetBranch), t.config.Since)
 }
@@ -791,7 +792,7 @@ func (t *Testing) CheckVersionIncrement(chart *Chart) error {
 	}
 
 	if result >= 0 {
-		return fmt.Errorf("chart version not ok. needs a version bump! ")
+		return errors.New("chart version not ok. Needs a version bump! ")
 	}
 
 	fmt.Println("Chart version ok.")
@@ -845,13 +846,13 @@ func (t *Testing) ValidateMaintainers(chart *Chart) error {
 
 	if chartYaml.Deprecated {
 		if len(chartYaml.Maintainers) > 0 {
-			return fmt.Errorf("deprecated chart must not have maintainers")
+			return errors.New("deprecated chart must not have maintainers")
 		}
 		return nil
 	}
 
 	if len(chartYaml.Maintainers) == 0 {
-		return fmt.Errorf("chart doesn't have maintainers")
+		return errors.New("chart doesn't have maintainers")
 	}
 
 	repoURL, err := t.git.GetURLForRemote(t.config.Remote)

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/helm/chart-testing/v3/pkg/config"
 	"github.com/helm/chart-testing/v3/pkg/util"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -63,7 +62,7 @@ func (g fakeGit) RemoveWorktree(path string) error {
 	return nil
 }
 
-func (g fakeGit) GetUrlForRemote(remote string) (string, error) {
+func (g fakeGit) GetURLForRemote(remote string) (string, error) {
 	return "git@github.com/helm/chart-testing", nil
 }
 
@@ -77,7 +76,7 @@ func (v fakeAccountValidator) Validate(repoDomain string, account string) error 
 	if strings.HasPrefix(account, "valid") {
 		return nil
 	}
-	return errors.New(fmt.Sprintf("Error validating account: %s", account))
+	return fmt.Errorf("failed validating account: %s", account)
 }
 
 type fakeLinter struct {
@@ -145,7 +144,7 @@ func newTestingMock(cfg config.Configuration) Testing {
 		config:           cfg,
 		directoryLister:  util.DirectoryLister{},
 		git:              fakeGit{},
-		chartUtils:       util.ChartUtils{},
+		utils:            util.Utils{},
 		accountValidator: fakeAccountValidator{},
 		linter:           fakeMockLinter,
 		helm:             new(fakeHelm),
@@ -299,7 +298,6 @@ func TestLintChartSchemaValidation(t *testing.T) {
 
 	runTests(true, 0, 1)
 	runTests(false, 0, 0)
-
 }
 
 func TestLintYamlValidation(t *testing.T) {

--- a/pkg/chart/integration_test.go
+++ b/pkg/chart/integration_test.go
@@ -38,7 +38,7 @@ func newTestingHelmIntegration(cfg config.Configuration, extraSetArgs string) Te
 		config:           cfg,
 		directoryLister:  util.DirectoryLister{},
 		git:              fakeGit{},
-		chartUtils:       util.ChartUtils{},
+		utils:            util.Utils{},
 		accountValidator: fakeAccountValidator{},
 		linter:           fakeMockLinter,
 		helm:             tool.NewHelm(procExec, extraArgs, strings.Fields(extraSetArgs)),

--- a/pkg/chart/integration_test.go
+++ b/pkg/chart/integration_test.go
@@ -121,7 +121,7 @@ func TestUpgradeChart(t *testing.T) {
 		Upgrade: true,
 	}
 	ct := newTestingHelmIntegration(cfg, "")
-	processError := fmt.Errorf("Error waiting for process: exit status 1")
+	processError := fmt.Errorf("failed waiting for process: exit status 1")
 
 	cases := []testCase{
 		{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -121,18 +122,18 @@ func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*C
 	}
 
 	if cfg.ProcessAllCharts && len(cfg.Charts) > 0 {
-		return nil, fmt.Errorf("specifying both, '--all' and '--charts', is not allowed")
+		return nil, errors.New("specifying both, '--all' and '--charts', is not allowed")
 	}
 
 	if cfg.Namespace != "" && cfg.ReleaseLabel == "" {
-		return nil, fmt.Errorf("specifying '--namespace' without '--release-label' is not allowed")
+		return nil, errors.New("specifying '--namespace' without '--release-label' is not allowed")
 	}
 
 	// Disable upgrade (this does some expensive dependency building on previous revisions)
 	// when neither "install" nor "lint-and-install" have not been specified.
 	cfg.Upgrade = isInstall && cfg.Upgrade
 	if (cfg.TargetBranch == "" || cfg.Remote == "") && cfg.Upgrade {
-		return nil, fmt.Errorf("specifying '--upgrade=true' without '--target-branch' or '--remote', is not allowed")
+		return nil, errors.New("specifying '--upgrade=true' without '--target-branch' or '--remote', is not allowed")
 	}
 
 	chartYamlSchemaPath := cfg.ChartYamlSchema
@@ -140,7 +141,7 @@ func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*C
 		var err error
 		cfgFile, err = findConfigFile("chart_schema.yaml")
 		if err != nil && isLint && cfg.ValidateChartSchema {
-			return nil, fmt.Errorf("'chart_schema.yaml' neither specified nor found in default locations")
+			return nil, errors.New("'chart_schema.yaml' neither specified nor found in default locations")
 		}
 		cfg.ChartYamlSchema = cfgFile
 	}
@@ -150,7 +151,7 @@ func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*C
 		var err error
 		cfgFile, err = findConfigFile("lintconf.yaml")
 		if err != nil && isLint && cfg.ValidateYaml {
-			return nil, fmt.Errorf("'lintconf.yaml' neither specified nor found in default locations")
+			return nil, errors.New("'lintconf.yaml' neither specified nor found in default locations")
 		}
 		cfg.LintConf = cfgFile
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -40,7 +40,7 @@ func loadAndAssertConfigFromFile(t *testing.T, configFile string) {
 
 	require.Equal(t, "origin", cfg.Remote)
 	require.Equal(t, "main", cfg.TargetBranch)
-	require.Equal(t, "pr-42", cfg.BuildId)
+	require.Equal(t, "pr-42", cfg.BuildID)
 	require.Equal(t, "my-lint-conf.yaml", cfg.LintConf)
 	require.Equal(t, "my-chart-yaml-schema.yaml", cfg.ChartYamlSchema)
 	require.Equal(t, true, cfg.ValidateMaintainers)

--- a/pkg/tool/account.go
+++ b/pkg/tool/account.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
-
-	"github.com/pkg/errors"
 )
 
 type AccountValidator struct{}
@@ -32,12 +30,12 @@ func (v AccountValidator) Validate(repoURL string, account string) error {
 		return err
 	}
 	url := fmt.Sprintf("https://%s/%s", domain, account)
-	response, err := http.Head(url)
+	response, err := http.Head(url) // nolint: gosec
 	if err != nil {
-		return errors.Wrap(err, "Error validating maintainers")
+		return fmt.Errorf("failed validating maintainers: %w", err)
 	}
 	if response.StatusCode != 200 {
-		return fmt.Errorf("Error validating maintainer '%s': %s", account, response.Status)
+		return fmt.Errorf("failed validating maintainer %q: %s", account, response.Status)
 	}
 	return nil
 }
@@ -46,7 +44,7 @@ func parseOutGitRepoDomain(repoURL string) (string, error) {
 	// This works for GitHub, Bitbucket, and Gitlab
 	submatch := repoDomainPattern.FindStringSubmatch(repoURL)
 	if submatch == nil || len(submatch) < 2 {
-		return "", fmt.Errorf("Could not parse git repository domain for '%s'", repoURL)
+		return "", fmt.Errorf("could not parse git repository domain for %q", repoURL)
 	}
 	return submatch[1], nil
 }

--- a/pkg/tool/account_test.go
+++ b/pkg/tool/account_test.go
@@ -23,7 +23,7 @@ func TestParseOutGitDomain(t *testing.T) {
 		{"Bitbucket SSH", "git@bitbucket.com:foo/bar", "bitbucket.com", nil},
 		{"Bitbucket HTTPS", "https://bitbucket.com/foo/bar", "bitbucket.com", nil},
 		{"Bitbucket HTTPS with username/password", "https://user:pass@bitbucket.com/foo/bar", "bitbucket.com", nil},
-		{"Invalid", "foo/bar", "", fmt.Errorf("Could not parse git repository domain for 'foo/bar'")},
+		{"Invalid", "foo/bar", "", fmt.Errorf("could not parse git repository domain for \"foo/bar\"")},
 	}
 
 	for _, testData := range testDataSlice {

--- a/pkg/tool/account_test.go
+++ b/pkg/tool/account_test.go
@@ -10,7 +10,7 @@ import (
 func TestParseOutGitDomain(t *testing.T) {
 	var testDataSlice = []struct {
 		name     string
-		repoUrl  string
+		repoURL  string
 		expected string
 		err      error
 	}{
@@ -28,7 +28,7 @@ func TestParseOutGitDomain(t *testing.T) {
 
 	for _, testData := range testDataSlice {
 		t.Run(testData.name, func(t *testing.T) {
-			actual, err := parseOutGitRepoDomain(testData.repoUrl)
+			actual, err := parseOutGitRepoDomain(testData.repoURL)
 			assert.Equal(t, err, testData.err)
 			assert.Equal(t, testData.expected, actual)
 		})

--- a/pkg/tool/cmdexecutor_test.go
+++ b/pkg/tool/cmdexecutor_test.go
@@ -69,8 +69,8 @@ func TestCmdTemplateExecutor_RunCommand(t *testing.T) {
 			if err := templateExecutor.RunCommand(tt.args.cmdTemplate, tt.args.data); (err != nil) != tt.wantErr {
 				t.Errorf("RunCommand() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			tt.validate(t, processExecutor)
 
+			tt.validate(t, processExecutor)
 		})
 	}
 }

--- a/pkg/tool/git.go
+++ b/pkg/tool/git.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	"github.com/helm/chart-testing/v3/pkg/exec"
-	"github.com/pkg/errors"
 )
 
 type Git struct {
@@ -59,7 +58,7 @@ func (g Git) ListChangedFilesInDirs(commit string, dirs ...string) ([]string, er
 	changedChartFilesString, err :=
 		g.exec.RunProcessAndCaptureOutput("git", "diff", "--find-renames", "--name-only", commit, "--", dirs)
 	if err != nil {
-		return nil, errors.Wrap(err, "Error creating diff")
+		return nil, fmt.Errorf("failed creating diff: %w", err)
 	}
 	if changedChartFilesString == "" {
 		return nil, nil
@@ -67,7 +66,7 @@ func (g Git) ListChangedFilesInDirs(commit string, dirs ...string) ([]string, er
 	return strings.Split(changedChartFilesString, "\n"), nil
 }
 
-func (g Git) GetUrlForRemote(remote string) (string, error) {
+func (g Git) GetURLForRemote(remote string) (string, error) {
 	return g.exec.RunProcessAndCaptureOutput("git", "ls-remote", "--get-url", remote)
 }
 

--- a/pkg/tool/helm.go
+++ b/pkg/tool/helm.go
@@ -83,7 +83,7 @@ func (h Helm) Test(namespace string, release string) error {
 }
 
 func (h Helm) DeleteRelease(namespace string, release string) {
-	fmt.Printf("Deleting release '%s'...\n", release)
+	fmt.Printf("Deleting release %q...\n", release)
 	if err := h.exec.RunProcess("helm", "uninstall", release, "--namespace", namespace, h.extraArgs); err != nil {
 		fmt.Println("Error deleting Helm release:", err)
 	}

--- a/pkg/tool/kubectl.go
+++ b/pkg/tool/kubectl.go
@@ -3,6 +3,7 @@ package tool
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -106,9 +107,9 @@ func (k Kubectl) forceNamespaceDeletion(namespace string) error {
 		client := retryablehttp.NewClient()
 		client.Logger = nil
 		if resp, err := client.Do(req); err != nil {
-			return fmt.Errorf(errMsg)
+			return fmt.Errorf("%s:%w", errMsg, err)
 		} else if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf(errMsg)
+			return errors.New(errMsg)
 		}
 
 		return nil

--- a/pkg/tool/kubectl.go
+++ b/pkg/tool/kubectl.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/helm/chart-testing/v3/pkg/exec"
-	"github.com/pkg/errors"
 )
 
 type Kubectl struct {
@@ -27,7 +26,7 @@ func NewKubectl(exec exec.ProcessExecutor, timeout time.Duration) Kubectl {
 
 // CreateNamespace creates a new namespace with the given name.
 func (k Kubectl) CreateNamespace(namespace string) error {
-	fmt.Printf("Creating namespace '%s'...\n", namespace)
+	fmt.Printf("Creating namespace %q...\n", namespace)
 	return k.exec.RunProcess("kubectl",
 		fmt.Sprintf("--request-timeout=%s", k.timeout),
 		"create", "namespace", namespace)
@@ -36,17 +35,17 @@ func (k Kubectl) CreateNamespace(namespace string) error {
 // DeleteNamespace deletes the specified namespace. If the namespace does not terminate within 120s, pods running in the
 // namespace and, eventually, the namespace itself are force-deleted.
 func (k Kubectl) DeleteNamespace(namespace string) {
-	fmt.Printf("Deleting namespace '%s'...\n", namespace)
+	fmt.Printf("Deleting namespace %q...\n", namespace)
 	timeoutSec := "180s"
 	err := k.exec.RunProcess("kubectl",
 		fmt.Sprintf("--request-timeout=%s", k.timeout),
 		"delete", "namespace", namespace, "--timeout", timeoutSec)
 	if err != nil {
-		fmt.Printf("Namespace '%s' did not terminate after %s.\n", namespace, timeoutSec)
+		fmt.Printf("Namespace %q did not terminate after %s.\n", namespace, timeoutSec)
 	}
 
 	if k.getNamespace(namespace) {
-		fmt.Printf("Namespace '%s' did not terminate after %s.\n", namespace, timeoutSec)
+		fmt.Printf("Namespace %q did not terminate after %s.\n", namespace, timeoutSec)
 
 		fmt.Println("Force-deleting everything...")
 		err = k.exec.RunProcess("kubectl",
@@ -93,7 +92,7 @@ func (k Kubectl) forceNamespaceDeletion(namespace string) error {
 
 	// Remove finalizer from the namespace
 	fun := func(port int) error {
-		fmt.Printf("Removing finalizers from namespace '%s'...\n", namespace)
+		fmt.Printf("Removing finalizers from namespace %q...\n", namespace)
 
 		k8sURL := fmt.Sprintf("http://127.0.0.1:%d/api/v1/namespaces/%s/finalize", port, namespace)
 		req, err := retryablehttp.NewRequest("PUT", k8sURL, bytes.NewReader(namespaceUpdateBytes))
@@ -107,9 +106,9 @@ func (k Kubectl) forceNamespaceDeletion(namespace string) error {
 		client := retryablehttp.NewClient()
 		client.Logger = nil
 		if resp, err := client.Do(req); err != nil {
-			return errors.Wrap(err, errMsg)
+			return fmt.Errorf(errMsg)
 		} else if resp.StatusCode != http.StatusOK {
-			return errors.New(errMsg)
+			return fmt.Errorf(errMsg)
 		}
 
 		return nil
@@ -117,7 +116,7 @@ func (k Kubectl) forceNamespaceDeletion(namespace string) error {
 
 	err = k.exec.RunWithProxy(fun)
 	if err != nil {
-		return errors.Wrapf(err, "Cannot force-delete namespace '%s'", namespace)
+		return fmt.Errorf("cannot force-delete namespace %q: %w", namespace, err)
 	}
 
 	// Give it some more time to be deleted by K8s
@@ -128,11 +127,11 @@ func (k Kubectl) forceNamespaceDeletion(namespace string) error {
 		fmt.Sprintf("--request-timeout=%s", k.timeout),
 		"get", "namespace", namespace)
 	if err != nil {
-		fmt.Printf("Namespace '%s' terminated.\n", namespace)
+		fmt.Printf("Namespace %q terminated.\n", namespace)
 		return nil
 	}
 
-	fmt.Printf("Force-deleting namespace '%s'...\n", namespace)
+	fmt.Printf("Force-deleting namespace %q...\n", namespace)
 	err = k.exec.RunProcess("kubectl",
 		fmt.Sprintf("--request-timeout=%s", k.timeout),
 		"delete", "namespace", namespace, "--force", "--grace-period=0",
@@ -250,7 +249,7 @@ func (k Kubectl) getNamespace(namespace string) bool {
 		fmt.Sprintf("--request-timeout=%s", k.timeout),
 		"get", "namespace", namespace)
 	if err != nil {
-		fmt.Printf("Namespace '%s' terminated.\n", namespace)
+		fmt.Printf("Namespace %q terminated.\n", namespace)
 		return false
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -154,7 +155,7 @@ func (u Utils) LookupChartDir(chartDirs []string, dir string) (string, error) {
 			}
 		}
 	}
-	return "", fmt.Errorf("no chart directory")
+	return "", errors.New("no chart directory")
 }
 
 // ReadChartYaml attempts to parse Chart.yaml within the specified directory


### PR DESCRIPTION
**What this PR does / why we need it**:
- upgrade to go1.19
- update helm to v3.9.3
- add golangci-lint
- fix lints and Replace github.com/pkg/errors dependency with native error wrapping

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
