### PR TITLE
Fix parsing kubectl output with warnings

### DIFF
--- a/pkg/tool/kubectl.go
+++ b/pkg/tool/kubectl.go
@@ -146,7 +146,7 @@ func (k Kubectl) forceNamespaceDeletion(namespace string) error {
 }
 
 func (k Kubectl) WaitForDeployments(namespace string, selector string) error {
-	output, err := k.exec.RunProcessAndCaptureOutput("kubectl",
+	output, err := k.exec.RunProcessAndCaptureStdout("kubectl",
 		fmt.Sprintf("--request-timeout=%s", k.timeout),
 		"get", "deployments", "--namespace", namespace, "--selector", selector,
 		"--output", "jsonpath={.items[*].metadata.name}")

--- a/pkg/tool/kubectl.go
+++ b/pkg/tool/kubectl.go
@@ -70,7 +70,7 @@ func (k Kubectl) DeleteNamespace(namespace string) {
 
 func (k Kubectl) forceNamespaceDeletion(namespace string) error {
 	// Getting the namespace json to remove the finalizer
-	cmdOutput, err := k.exec.RunProcessAndCaptureOutput("kubectl",
+	cmdOutput, err := k.exec.RunProcessAndCaptureStdout("kubectl",
 		fmt.Sprintf("--request-timeout=%s", k.timeout),
 		"get", "namespace", namespace, "--output=json")
 	if err != nil {
@@ -169,7 +169,7 @@ func (k Kubectl) WaitForDeployments(namespace string, selector string) error {
 		//
 		// Just after rollout, pods from the previous deployment revision may still be in a
 		// terminating state.
-		unavailable, err := k.exec.RunProcessAndCaptureOutput("kubectl",
+		unavailable, err := k.exec.RunProcessAndCaptureStdout("kubectl",
 			fmt.Sprintf("--request-timeout=%s", k.timeout),
 			"get", "deployment", deployment, "--namespace", namespace, "--output",
 			`jsonpath={.status.unavailableReplicas}`)
@@ -185,7 +185,7 @@ func (k Kubectl) WaitForDeployments(namespace string, selector string) error {
 }
 
 func (k Kubectl) GetPodsforDeployment(namespace string, deployment string) ([]string, error) {
-	jsonString, _ := k.exec.RunProcessAndCaptureOutput("kubectl",
+	jsonString, _ := k.exec.RunProcessAndCaptureStdout("kubectl",
 		fmt.Sprintf("--request-timeout=%s", k.timeout),
 		"get", "deployment", deployment, "--namespace", namespace, "--output=json")
 	var deploymentMap map[string]interface{}
@@ -211,7 +211,7 @@ func (k Kubectl) GetPodsforDeployment(namespace string, deployment string) ([]st
 func (k Kubectl) GetPods(args ...string) ([]string, error) {
 	kubectlArgs := []string{"get", "pods"}
 	kubectlArgs = append(kubectlArgs, args...)
-	pods, err := k.exec.RunProcessAndCaptureOutput("kubectl",
+	pods, err := k.exec.RunProcessAndCaptureStdout("kubectl",
 		fmt.Sprintf("--request-timeout=%s", k.timeout), kubectlArgs)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Exclude stderr (e.g. deprecation warnings) when parsing command output.

**What this PR does / why we need it**: It ensures that warnings or other output that goes to stderr won't be parsed when trying to list deployments, pods, etc. Today, this is not the case, and many  `ct` subcommands will fail in such situations (e.g. when the [gke-gcloud-auth-plugin](https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke) isn't yet installed).

**Special notes for your reviewer**:
It's possible that the original implementation wanted to include stderr in the output for these commands for a reason, but this feels like a simple oversight.

It's also possible that there are other similar places in the code that require the same modification, so please feel free to update the PR or request these changes, which I will then apply. Thanks!