### PR TITLE
Add config option to disable printing of container logs

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -901,22 +901,24 @@ func (t *Testing) PrintEventsPodDetailsAndLogs(namespace string, selector string
 			return
 		}
 
-		printDetails(pod, "Logs of init container", "-",
-			func(item string) error {
-				return t.kubectl.Logs(namespace, pod, item)
-			}, initContainers...)
+		if t.config.PrintLogs {
+			printDetails(pod, "Logs of init container", "-",
+				func(item string) error {
+					return t.kubectl.Logs(namespace, pod, item)
+				}, initContainers...)
 
-		containers, err := t.kubectl.GetContainers(namespace, pod)
-		if err != nil {
-			fmt.Printf("failed printing logs: %v\n", err.Error())
-			return
+			containers, err := t.kubectl.GetContainers(namespace, pod)
+			if err != nil {
+				fmt.Printf("failed printing logs: %v\n", err.Error())
+				return
+			}
+
+			printDetails(pod, "Logs of container", "-",
+				func(item string) error {
+					return t.kubectl.Logs(namespace, pod, item)
+				},
+				containers...)
 		}
-
-		printDetails(pod, "Logs of container", "-",
-			func(item string) error {
-				return t.kubectl.Logs(namespace, pod, item)
-			},
-			containers...)
 	}
 
 	util.PrintDelimiterLineToWriter(os.Stdout, "=")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -68,12 +68,14 @@ type Configuration struct {
 	ReleaseLabel            string        `mapstructure:"release-label"`
 	ExcludeDeprecated       bool          `mapstructure:"exclude-deprecated"`
 	KubectlTimeout          time.Duration `mapstructure:"kubectl-timeout"`
+	PrintLogs               bool          `mapstructure:"print-logs"`
 }
 
 func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*Configuration, error) {
 	v := viper.New()
 
 	v.SetDefault("kubectl-timeout", 30*time.Second)
+	v.SetDefault("print-logs", bool(true))
 
 	cmd.Flags().VisitAll(func(flag *flag.Flag) {
 		flagName := flag.Name


### PR DESCRIPTION
**What this PR does / why we need it**:

In some instances `ct` will stall indefinitely if the log output from the containers is too long.  This PR introduces a new configuration option that will disable printing of the container logs.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #471 

**Special notes for your reviewer**:

I am sure this PR isn't ideal, but I am not really sure how to work around my issue.  I can say for sure that since using my patched version of `ct` where log printing is disabled, I have not had `ct` hang on any job I have ran locally or in a CI job.
