### PR TITLE
fix: using helm version --short resulting in an invalid semantic versioning

### DIFF
--- a/pkg/tool/helm.go
+++ b/pkg/tool/helm.go
@@ -90,5 +90,5 @@ func (h Helm) DeleteRelease(namespace string, release string) {
 }
 
 func (h Helm) Version() (string, error) {
-	return h.exec.RunProcessAndCaptureStdout("helm", "version", "--short")
+	return h.exec.RunProcessAndCaptureStdout("helm", "version", "--template", "{{ .Version }}")
 }


### PR DESCRIPTION
Signed-off-by: Sushanta Das <sushanta.das.ju@gmail.com>

**What this PR does / why we need it**:

On using `helm version --short` resulting in invalid sematic version if the version includes a build part in the version string.
Instead we can use the `helm version --template {{ .Version }}` to get the helm version. Please see the issue for more information about the problem.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

fixes https://github.com/helm/chart-testing/issues/467 
