### PR TITLE
add skip-clean-up option to not remove the charts when finishing the tests

### DIFF
--- a/ct/cmd/install.go
+++ b/ct/cmd/install.go
@@ -80,6 +80,8 @@ func addInstallFlags(flags *flag.FlagSet) {
 	flags.String("helm-extra-set-args", "", heredoc.Doc(`
 		Additional arguments for Helm. Must be passed as a single quoted string
 		(e.g. "--set=name=value"`))
+	flags.Bool("skip-clean-up", false, heredoc.Doc(`
+		Skip resources clean-up. Used if need to continue other flows or keep it around.`))
 }
 
 func install(cmd *cobra.Command, args []string) error {

--- a/doc/ct_install.md
+++ b/doc/ct_install.md
@@ -66,6 +66,7 @@ ct install [flags]
                                              This is only used if namespace is specified (default "app.kubernetes.io/instance")
       --remote string                        The name of the Git remote used to identify changed charts (default "origin")
       --since string                         The Git reference used to identify changed charts (default "HEAD")
+      --skip-clean-up                        Skip resources clean-up. Used if need to continue other flows or keep it around.
       --skip-missing-values                  When --upgrade has been passed, this flag will skip testing CI values files from the
                                              previous chart revision if they have been deleted or renamed at the current chart
                                              revision

--- a/doc/ct_lint-and-install.md
+++ b/doc/ct_lint-and-install.md
@@ -61,6 +61,7 @@ ct lint-and-install [flags]
                                              This is only used if namespace is specified (default "app.kubernetes.io/instance")
       --remote string                        The name of the Git remote used to identify changed charts (default "origin")
       --since string                         The Git reference used to identify changed charts (default "HEAD")
+      --skip-clean-up                        Skip resources clean-up. Used if need to continue other flows or keep it around.
       --skip-missing-values                  When --upgrade has been passed, this flag will skip testing CI values files from the
                                              previous chart revision if they have been deleted or renamed at the current chart
                                              revision

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -564,7 +564,9 @@ func (t *Testing) doInstall(chart *Chart) error {
 		// and be executed in reverse order after the loop.
 		fun := func() error {
 			namespace, release, releaseSelector, cleanup := t.generateInstallConfig(chart)
-			defer cleanup()
+			if !t.config.SkipCleanUp {
+				defer cleanup()
+			}
 
 			if t.config.Namespace == "" {
 				if err := t.kubectl.CreateNamespace(namespace); err != nil {
@@ -604,7 +606,9 @@ func (t *Testing) doUpgrade(oldChart, newChart *Chart, oldChartMustPass bool) er
 		// and be executed in reverse order after the loop.
 		fun := func() error {
 			namespace, release, releaseSelector, cleanup := t.generateInstallConfig(oldChart)
-			defer cleanup()
+			if !t.config.SkipCleanUp {
+				defer cleanup()
+			}
 
 			if t.config.Namespace == "" {
 				if err := t.kubectl.CreateNamespace(namespace); err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -64,6 +64,7 @@ type Configuration struct {
 	Debug                   bool          `mapstructure:"debug"`
 	Upgrade                 bool          `mapstructure:"upgrade"`
 	SkipMissingValues       bool          `mapstructure:"skip-missing-values"`
+	SkipCleanUp             bool          `mapstructure:"skip-clean-up"`
 	Namespace               string        `mapstructure:"namespace"`
 	ReleaseLabel            string        `mapstructure:"release-label"`
 	ExcludeDeprecated       bool          `mapstructure:"exclude-deprecated"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -59,6 +59,7 @@ func loadAndAssertConfigFromFile(t *testing.T, configFile string) {
 	require.Equal(t, "release", cfg.ReleaseLabel)
 	require.Equal(t, true, cfg.ExcludeDeprecated)
 	require.Equal(t, 120*time.Second, cfg.KubectlTimeout)
+	require.Equal(t, true, cfg.SkipCleanUp)
 }
 
 func Test_findConfigFile(t *testing.T) {

--- a/pkg/config/test_config.json
+++ b/pkg/config/test_config.json
@@ -30,5 +30,6 @@
     "namespace": "default",
     "release-label": "release",
     "exclude-deprecated": true,
-    "kubectl-timeout": "120s"
+    "kubectl-timeout": "120s",
+    "skip-clean-up": true
 }

--- a/pkg/config/test_config.yaml
+++ b/pkg/config/test_config.yaml
@@ -26,3 +26,4 @@ namespace: default
 release-label: release
 exclude-deprecated: true
 kubectl-timeout: 120s
+skip-clean-up: true


### PR DESCRIPTION
**What this PR does / why we need it**:

- add skip-clean-up option to not remove the charts when finishing the tests

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
