### PR TITLE
LintWithValues now iterates through list of value files

### DIFF
--- a/ct/cmd/root.go
+++ b/ct/cmd/root.go
@@ -102,4 +102,7 @@ func addCommonLintAndInstallFlags(flags *pflag.FlagSet) {
 	flags.Bool("debug", false, heredoc.Doc(`
 		Print CLI calls of external tools to stdout (caution: setting this may
 		expose sensitive data when helm-repo-extra-args contains passwords)`))
+	flags.StringSlice("extra-values", []string{}, heredoc.Doc(`
+		Additional value files (will be deep merged with defaults values for charts
+		as well as value files of the format "*-values.yaml" under the "ci" folder`))
 }

--- a/ct/main.go
+++ b/ct/main.go
@@ -15,7 +15,7 @@
 package main
 
 import (
-	"github.com/helm/chart-testing/v3/ct/cmd"
+	"github.com/scrungus/chart-testing/v3/ct/cmd"
 )
 
 func main() {

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -84,7 +84,7 @@ type Helm interface {
 	AddRepo(name string, url string, extraArgs []string) error
 	BuildDependencies(chart string) error
 	BuildDependenciesWithArgs(chart string, extraArgs []string) error
-	LintWithValues(chart string, valuesFile string) error
+	LintWithValues(chart string, valuesFile []string) error
 	InstallWithValues(chart string, valuesFile string, namespace string, release string) error
 	Upgrade(chart string, namespace string, release string) error
 	Test(namespace string, release string) error
@@ -481,10 +481,16 @@ func (t *Testing) LintChart(chart *Chart) TestResult {
 	}
 
 	for _, valuesFile := range valuesFiles {
+		// Lint with extra value files if specified
+		extraValues := append(t.config.ExtraValues, valuesFile)
+
 		if valuesFile != "" {
-			fmt.Printf("\nLinting chart with values file %q...\n\n", valuesFile)
+			fmt.Printf("\nLinting chart with values file %q...", valuesFile)
 		}
-		if err := t.helm.LintWithValues(chart.Path(), valuesFile); err != nil {
+		if len(t.config.ExtraValues) > 0 {
+			fmt.Printf("\nIncluding extra value files: %s...\n\n", strings.Join(t.config.ExtraValues, ", "))
+		}
+		if err := t.helm.LintWithValues(chart.Path(), extraValues); err != nil {
 			result.Error = err
 			break
 		}

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -102,7 +102,7 @@ func (h *fakeHelm) BuildDependenciesWithArgs(chart string, extraArgs []string) e
 	h.Called(chart, extraArgs)
 	return nil
 }
-func (h *fakeHelm) LintWithValues(chart string, valuesFile string) error { return nil }
+func (h *fakeHelm) LintWithValues(chart string, valuesFile []string) error { return nil }
 func (h *fakeHelm) InstallWithValues(chart string, valuesFile string, namespace string, release string) error {
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -71,6 +71,7 @@ type Configuration struct {
 	ExcludeDeprecated       bool          `mapstructure:"exclude-deprecated"`
 	KubectlTimeout          time.Duration `mapstructure:"kubectl-timeout"`
 	PrintLogs               bool          `mapstructure:"print-logs"`
+	ExtraValues             []string      `mapstructure:"extra-values"`
 }
 
 func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*Configuration, error) {

--- a/pkg/tool/helm.go
+++ b/pkg/tool/helm.go
@@ -55,8 +55,6 @@ func (h Helm) LintWithValues(chart string, valuesFiles []string) error {
 		}
 	}
 
-	fmt.Print("cmd line argument sent :", values)
-
 	return h.exec.RunProcess("helm", "lint", chart, values)
 }
 

--- a/pkg/tool/helm.go
+++ b/pkg/tool/helm.go
@@ -46,11 +46,16 @@ func (h Helm) BuildDependenciesWithArgs(chart string, extraArgs []string) error 
 	return h.exec.RunProcess("helm", "dependency", "build", chart, extraArgs)
 }
 
-func (h Helm) LintWithValues(chart string, valuesFile string) error {
+func (h Helm) LintWithValues(chart string, valuesFiles []string) error {
 	var values []string
-	if valuesFile != "" {
-		values = []string{"--values", valuesFile}
+	for _, valuesFile := range valuesFiles {
+
+		if valuesFile != "" {
+			values = append(values, []string{"--values", valuesFile}...)
+		}
 	}
+
+	fmt.Print("cmd line argument sent :", values)
 
 	return h.exec.RunProcess("helm", "lint", chart, values)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to helm/chart-testing.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Currently, it is not possible to include extra value files in `ct lint` as you would through helm (e.g. `helm lint -f x.yml -f y.yml -f etc...`. This is important for CI jobs where for example, you need to include a github CI secret in a workflow, that you do not want to store as a file in the repo. This PR enables users to pass files via `ct lint --extra-values mycreds.yml`

**Which issue this PR fixes** : fixes #499

**Special notes for your reviewer**:
As there is no contributor documentation (at least that I could find), I'm not sure what needs to get this ready for production, in terms of fixing tests/documentation etc. Probably needs a fair bit of work.