### PR TITLE
fix(lint): honor the --since flag when checking for version increment

### DIFF
--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -27,11 +27,11 @@ import (
 
 type fakeGit struct{}
 
-func (g fakeGit) FileExistsOnBranch(file string, remote string, branch string) bool {
+func (g fakeGit) FileExistsOnBranch(commit string, file string) bool {
 	return true
 }
 
-func (g fakeGit) Show(file string, remote string, branch string) (string, error) {
+func (g fakeGit) Show(commit string, file string) (string, error) {
 	return "", nil
 }
 

--- a/pkg/tool/git.go
+++ b/pkg/tool/git.go
@@ -31,8 +31,8 @@ func NewGit(exec exec.ProcessExecutor) Git {
 	}
 }
 
-func (g Git) FileExistsOnBranch(file string, remote string, branch string) bool {
-	fileSpec := fmt.Sprintf("%s/%s:%s", remote, branch, file)
+func (g Git) FileExistsOnBranch(commit string, file string) bool {
+	fileSpec := fmt.Sprintf("%s:%s", commit, file)
 	_, err := g.exec.RunProcessAndCaptureOutput("git", "cat-file", "-e", fileSpec)
 	return err == nil
 }
@@ -45,8 +45,8 @@ func (g Git) RemoveWorktree(path string) error {
 	return g.exec.RunProcess("git", "worktree", "remove", path)
 }
 
-func (g Git) Show(file string, remote string, branch string) (string, error) {
-	fileSpec := fmt.Sprintf("%s/%s:%s", remote, branch, file)
+func (g Git) Show(commit string, file string) (string, error) {
+	fileSpec := fmt.Sprintf("%s:%s", commit, file)
 	return g.exec.RunProcessAndCaptureOutput("git", "show", fileSpec)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
With the current implementation `ct lint` does not use the existing `--since` flag when checking for a version increment.
This is problematic when you want to use `ct lint` to validate the difference between the checked out commit and a previous commit on the same branch. As `ct lint` tries to validate a difference between the current file and `origin/main` and these are the same files.

It is also misleading to have a different way of handling the `--since` flag between `lint` and `list-changed`.

I changed the code to use the same logic as in `ct list-changed` to determine the base of the change when validating the version increment.

Here are the verbose logs for before and after the change, we can see the difference in git commands issued:
<details>
  <summary>Before</summary>

```
ct lint --target-branch main --since 6541404b08b5afb68974a8f41dedb764725f89ea --debug
Linting charts...
>>> helm version --template {{ .Version }}
>>> git rev-parse --is-inside-work-tree
>>> git merge-base origin/main 6541404b08b5afb68974a8f41dedb764725f89ea
>>> git diff --find-renames --name-only 6541404b08b5afb68974a8f41dedb764725f89ea -- charts

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 service => (version: "0.2.0-alpha.1", path: "charts/service")
------------------------------------------------------------------------------------------------------------------------

>>> helm dependency build charts/service
Linting chart "service => (version: \"0.2.0-alpha.1\", path: \"charts/service\")"
Checking chart "service => (version: \"0.2.0-alpha.1\", path: \"charts/service\")" for a version bump...
>>> git cat-file -e origin/main:charts/service/Chart.yaml
>>> git show origin/main:charts/service/Chart.yaml
Old chart version: 0.2.0-alpha.2
New chart version: 0.2.0-alpha.1
------------------------------------------------------------------------------------------------------------------------
 ✖︎ service => (version: "0.2.0-alpha.1", path: "charts/service") > chart version not ok. Needs a version bump!
------------------------------------------------------------------------------------------------------------------------
Error: failed linting charts: failed processing charts
failed linting charts: failed processing charts
```

</details>

<details>
  <summary>After</summary>

```
 ct lint --target-branch main --since 6541404b08b5afb68974a8f41dedb764725f89ea --debug
Linting charts...
>>> helm version --template {{ .Version }}
>>> git rev-parse --is-inside-work-tree
>>> git merge-base origin/main 6541404b08b5afb68974a8f41dedb764725f89ea
>>> git diff --find-renames --name-only 6541404b08b5afb68974a8f41dedb764725f89ea -- charts

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 service => (version: "0.2.0-alpha.1", path: "charts/service")
------------------------------------------------------------------------------------------------------------------------

>>> helm dependency build charts/service
Linting chart "service => (version: \"0.2.0-alpha.1\", path: \"charts/service\")"
Checking chart "service => (version: \"0.2.0-alpha.1\", path: \"charts/service\")" for a version bump...
>>> git rev-parse --is-inside-work-tree
>>> git merge-base origin/main 6541404b08b5afb68974a8f41dedb764725f89ea
>>> git cat-file -e 6541404b08b5afb68974a8f41dedb764725f89ea:charts/service/Chart.yaml
>>> git show 6541404b08b5afb68974a8f41dedb764725f89ea:charts/service/Chart.yaml
Old chart version: 0.1.0-a9
New chart version: 0.2.0-alpha.1
Chart version ok.
>>> yamale --schema /usr/local/etc/ct/chart_schema.yaml charts/service/Chart.yaml
Validating /charts/service/Chart.yaml...
Validation success! 👍
>>> yamllint --config-file /usr/local/etc/ct/lintconf.yaml charts/service/Chart.yaml
------------------------------------------------------------------------------------------------------------------------
 ✖︎ service => (version: "0.2.0-alpha.1", path: "charts/service") > failed running process: exec: "yamllint": executable file not found in $PATH
------------------------------------------------------------------------------------------------------------------------
Error: failed linting charts: failed processing charts
failed linting charts: failed processing charts
```

</details>