### PR TITLE
(Breaking change) chore: change default target-branch to main

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,3 +1,3 @@
 # Community Code of Conduct
 
-Helm follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+Helm follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).

--- a/ct/cmd/root.go
+++ b/ct/cmd/root.go
@@ -65,7 +65,7 @@ func Execute() {
 func addCommonFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&cfgFile, "config", "", "Config file")
 	flags.String("remote", "origin", "The name of the Git remote used to identify changed charts")
-	flags.String("target-branch", "master", "The name of the target branch used to identify changed charts")
+	flags.String("target-branch", "main", "The name of the target branch used to identify changed charts")
 	flags.String("since", "HEAD", "The Git reference used to identify changed charts")
 	flags.StringSlice("chart-dirs", []string{"charts"}, heredoc.Doc(`
 		Directories containing Helm charts. May be specified multiple times

--- a/doc/ct_install.md
+++ b/doc/ct_install.md
@@ -72,7 +72,7 @@ ct install [flags]
       --skip-missing-values                  When --upgrade has been passed, this flag will skip testing CI values files from the
                                              previous chart revision if they have been deleted or renamed at the current chart
                                              revision
-      --target-branch string                 The name of the target branch used to identify changed charts (default "master")
+      --target-branch string                 The name of the target branch used to identify changed charts (default "main")
       --upgrade                              Whether to test an in-place upgrade of each chart from its previous revision if the
                                              current version should not introduce a breaking change according to the SemVer spec
 ```

--- a/doc/ct_lint-and-install.md
+++ b/doc/ct_lint-and-install.md
@@ -67,7 +67,7 @@ ct lint-and-install [flags]
       --skip-missing-values                  When --upgrade has been passed, this flag will skip testing CI values files from the
                                              previous chart revision if they have been deleted or renamed at the current chart
                                              revision
-      --target-branch string                 The name of the target branch used to identify changed charts (default "master")
+      --target-branch string                 The name of the target branch used to identify changed charts (default "main")
       --upgrade                              Whether to test an in-place upgrade of each chart from its previous revision if the
                                              current version should not introduce a breaking change according to the SemVer spec
       --validate-chart-schema                Enable schema validation of 'Chart.yaml' using Yamale (default true)

--- a/doc/ct_lint.md
+++ b/doc/ct_lint.md
@@ -67,7 +67,7 @@ ct lint [flags]
                                              expose sensitive data when helm-repo-extra-args contains passwords)
       --remote string                        The name of the Git remote used to identify changed charts (default "origin")
       --since string                         The Git reference used to identify changed charts (default "HEAD")
-      --target-branch string                 The name of the target branch used to identify changed charts (default "master")
+      --target-branch string                 The name of the target branch used to identify changed charts (default "main")
       --validate-chart-schema                Enable schema validation of 'Chart.yaml' using Yamale (default true)
       --validate-maintainers                 Enable validation of maintainer account names in chart.yml.
                                              Works for GitHub, GitLab, and Bitbucket (default true)

--- a/doc/ct_list-changed.md
+++ b/doc/ct_list-changed.md
@@ -27,7 +27,7 @@ ct list-changed [flags]
                                   expose sensitive data when helm-repo-extra-args contains passwords)
       --remote string             The name of the Git remote used to identify changed charts (default "origin")
       --since string              The Git reference used to identify changed charts (default "HEAD")
-      --target-branch string      The name of the target branch used to identify changed charts (default "master")
+      --target-branch string      The name of the target branch used to identify changed charts (default "main")
 ```
 
 ### SEE ALSO

--- a/examples/kind/README.md
+++ b/examples/kind/README.md
@@ -3,5 +3,5 @@
 `kind` is a tool for running local Kubernetes clusters using Docker container "nodes".
 
 This example shows how to lint and test charts using CircleCi and [kind](https://github.com/kubernetes-sigs/kind).
-It creates a cluster with a single master node and one worker node.
+It creates a cluster with a single main node and one worker node.
 The cluster configuration can be adjusted in [kind-config.yaml](test/kind-config.yaml). You can check for available configuration options in `kind` [docs](https://kind.sigs.k8s.io/docs/user/quick-start#configuring-your-kind-cluster)

--- a/examples/kind/README.md
+++ b/examples/kind/README.md
@@ -3,5 +3,5 @@
 `kind` is a tool for running local Kubernetes clusters using Docker container "nodes".
 
 This example shows how to lint and test charts using CircleCi and [kind](https://github.com/kubernetes-sigs/kind).
-It creates a cluster with a single main node and one worker node.
+It creates a cluster with a single control-plane node and one worker node.
 The cluster configuration can be adjusted in [kind-config.yaml](test/kind-config.yaml). You can check for available configuration options in `kind` [docs](https://kind.sigs.k8s.io/docs/user/quick-start#configuring-your-kind-cluster)


### PR DESCRIPTION
<!--
Thank you for contributing to helm/chart-testing.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

Because the default branch on GitHub is [`main`](https://github.blog/changelog/2020-10-01-the-default-branch-for-newly-created-repositories-is-now-main/) and not longer `master` this should also be the default to chart-testing.

**Which issue this PR fixes**:

fixes #376 

**Special notes for your reviewer**:

BREAKING CHANGE:
If e.g an action or workflow is not using an explicit specified `target-branch` the job might will fail after this change.

But after this change new users does not have the problem that a wrong branch is used.
For example I was suffering with the error message `exit status 128`- see #330 because the default branch was not `main`.