### PR TITLE
feat: verify if targetBranch is present in git repo

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -708,7 +708,7 @@ func (t *Testing) computeMergeBase() (string, error) {
 	}
 
 	if !t.git.BranchExists(t.config.TargetBranch) {
-		return "", errors.New(fmt.Sprintf("targetBranch '%s' does not exist", t.config.TargetBranch))
+		return "", fmt.Errorf("targetBranch '%s' does not exist", t.config.TargetBranch)
 	}
 
 	return t.git.MergeBase(fmt.Sprintf("%s/%s", t.config.Remote, t.config.TargetBranch), t.config.Since)

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -49,6 +49,8 @@ const maxNameLength = 63
 //
 // ValidateRepository checks that the current working directory is a valid git repository,
 // and returns nil if valid.
+//
+// BranchExists checks whether a given branch exists in the git repository.
 type Git interface {
 	FileExistsOnBranch(file string, remote string, branch string) bool
 	Show(file string, remote string, branch string) (string, error)
@@ -58,6 +60,7 @@ type Git interface {
 	ListChangedFilesInDirs(commit string, dirs ...string) ([]string, error)
 	GetURLForRemote(remote string) (string, error)
 	ValidateRepository() error
+	BranchExists(branch string) bool
 }
 
 // Helm is the interface that wraps Helm operations
@@ -703,6 +706,11 @@ func (t *Testing) computeMergeBase() (string, error) {
 	if err != nil {
 		return "", errors.New("must be in a git repository")
 	}
+
+	if !t.git.BranchExists(t.config.TargetBranch) {
+		return "", errors.New(fmt.Sprintf("targetBranch '%s' does not exist", t.config.TargetBranch))
+	}
+
 	return t.git.MergeBase(fmt.Sprintf("%s/%s", t.config.Remote, t.config.TargetBranch), t.config.Since)
 }
 

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -70,6 +70,10 @@ func (g fakeGit) ValidateRepository() error {
 	return nil
 }
 
+func (g fakeGit) BranchExists(branch string) bool {
+	return true
+}
+
 type fakeAccountValidator struct{}
 
 func (v fakeAccountValidator) Validate(repoDomain string, account string) error {

--- a/pkg/tool/git.go
+++ b/pkg/tool/git.go
@@ -74,3 +74,8 @@ func (g Git) ValidateRepository() error {
 	_, err := g.exec.RunProcessAndCaptureOutput("git", "rev-parse", "--is-inside-work-tree")
 	return err
 }
+
+func (g Git) BranchExists(branch string) bool {
+	_, err := g.exec.RunProcessAndCaptureOutput("git", "rev-parse", "--verify", branch)
+	return err == nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

If a targetBranch is not present in the git repository the `ct list-changed` command will fail. The error message for this is not really meaningful.

This PR will validate if the branch exists and throw a error message which the user will understand.

Because the default branch in GitHub changed from `master` to [`main`](https://github.blog/changelog/2020-10-01-the-default-branch-for-newly-created-repositories-is-now-main/) this is a common problem users are facing.

I've built the chart-testing and tested it with master branch as follows:

```bash
$ ct list-changed
Error: targetBranch 'master' does not exist
targetBranch 'master' does not exist
```

**Which issue this PR fixes**:

closes #330

**Special notes for your reviewer**:

- I am not sure if I should add a test here..
  other functions are not really care about it as `FileExistsOnBranch` for example:
  https://github.com/helm/chart-testing/blob/89d34943ed04b8bacad9693c6130f28a6fb3a6c7/pkg/chart/chart_test.go#L30-L32

- related to #510