### PR TITLE
allow reuse-values on upgrade to be configurable

### DIFF
--- a/ct/cmd/install.go
+++ b/ct/cmd/install.go
@@ -82,6 +82,9 @@ func addInstallFlags(flags *flag.FlagSet) {
 		(e.g. "--set=name=value"`))
 	flags.Bool("skip-clean-up", false, heredoc.Doc(`
 		Skip resources clean-up. Used if need to continue other flows or keep it around.`))
+	flags.Bool("reuse-values", true, heredoc.Doc(`
+		Can be reset to disable adding the reuse-values flag for upgrades when
+		using the --upgrade flag.`))
 }
 
 func install(cmd *cobra.Command, args []string) error {

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -260,7 +260,7 @@ func NewTesting(config config.Configuration, extraSetArgs string) (Testing, erro
 
 	testing := Testing{
 		config:           config,
-		helm:             tool.NewHelm(procExec, extraArgs, strings.Fields(extraSetArgs)),
+		helm:             tool.NewHelm(procExec, extraArgs, strings.Fields(extraSetArgs), config.ReuseValues),
 		git:              tool.NewGit(procExec),
 		kubectl:          tool.NewKubectl(procExec, config.KubectlTimeout),
 		linter:           tool.NewLinter(procExec),

--- a/pkg/chart/integration_test.go
+++ b/pkg/chart/integration_test.go
@@ -41,7 +41,7 @@ func newTestingHelmIntegration(cfg config.Configuration, extraSetArgs string) Te
 		utils:            util.Utils{},
 		accountValidator: fakeAccountValidator{},
 		linter:           fakeMockLinter,
-		helm:             tool.NewHelm(procExec, extraArgs, strings.Fields(extraSetArgs)),
+		helm:             tool.NewHelm(procExec, extraArgs, strings.Fields(extraSetArgs), cfg.ReuseValues),
 		kubectl:          tool.NewKubectl(procExec, 30*time.Second),
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -71,6 +71,7 @@ type Configuration struct {
 	ExcludeDeprecated       bool          `mapstructure:"exclude-deprecated"`
 	KubectlTimeout          time.Duration `mapstructure:"kubectl-timeout"`
 	PrintLogs               bool          `mapstructure:"print-logs"`
+	ReuseValues             bool          `mapstructure:"reuse-values"`
 }
 
 func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*Configuration, error) {

--- a/pkg/tool/helm.go
+++ b/pkg/tool/helm.go
@@ -24,13 +24,15 @@ type Helm struct {
 	exec         exec.ProcessExecutor
 	extraArgs    []string
 	extraSetArgs []string
+	reuseValues  bool
 }
 
-func NewHelm(exec exec.ProcessExecutor, extraArgs []string, extraSetArgs []string) Helm {
+func NewHelm(exec exec.ProcessExecutor, extraArgs []string, extraSetArgs []string, reuseValues bool) Helm {
 	return Helm{
 		exec:         exec,
 		extraArgs:    extraArgs,
 		extraSetArgs: extraSetArgs,
+		reuseValues:  reuseValues,
 	}
 }
 
@@ -70,8 +72,12 @@ func (h Helm) InstallWithValues(chart string, valuesFile string, namespace strin
 }
 
 func (h Helm) Upgrade(chart string, namespace string, release string) error {
+	var reuseValuesFlag string
+	if h.reuseValues {
+		reuseValuesFlag = "--reuse-values"
+	}
 	if err := h.exec.RunProcess("helm", "upgrade", release, chart, "--namespace", namespace,
-		"--reuse-values", "--wait", h.extraArgs, h.extraSetArgs); err != nil {
+		reuseValuesFlag, "--wait", h.extraArgs, h.extraSetArgs); err != nil {
 		return err
 	}
 


### PR DESCRIPTION


<!--
Thank you for contributing to helm/chart-testing.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

many charts add new values between chart versions. When using the reuse-values flag, those charts fail because reuse-values ignores the default values file.

By making this configurable, it allows the chart maintainer to determine whether it's appropriate for their chart to add new values when upgrading.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #525 

**Special notes for your reviewer**:
