### PR TITLE
add github grouping of log lines

### DIFF
--- a/ct/cmd/root.go
+++ b/ct/cmd/root.go
@@ -77,6 +77,9 @@ func addCommonFlags(flags *pflag.FlagSet) {
 		Prints the configuration to stderr (caution: setting this may
 		expose sensitive data when helm-repo-extra-args contains passwords)`))
 	flags.Bool("exclude-deprecated", false, "Skip charts that are marked as deprecated")
+	flags.Bool("github-groups", false, heredoc.Doc(`
+		Change the delimiters for github to create collapsible groups
+		for command output`))
 }
 
 func addCommonLintAndInstallFlags(flags *pflag.FlagSet) {

--- a/doc/ct_install.md
+++ b/doc/ct_install.md
@@ -48,6 +48,8 @@ ct install [flags]
       --exclude-deprecated                   Skip charts that are marked as deprecated
       --excluded-charts strings              Charts that should be skipped. May be specified multiple times
                                              or separate values with commas
+      --github-groups                        Change the delimiters for github to create collapsible groups
+                                             for command output
       --helm-dependency-extra-args strings   Additional arguments for 'helm dependency build' (e.g. ["--skip-refresh"]
       --helm-extra-args string               Additional arguments for Helm. Must be passed as a single quoted string
                                              (e.g. "--timeout 500s"

--- a/doc/ct_lint-and-install.md
+++ b/doc/ct_lint-and-install.md
@@ -40,6 +40,8 @@ ct lint-and-install [flags]
       --exclude-deprecated                   Skip charts that are marked as deprecated
       --excluded-charts strings              Charts that should be skipped. May be specified multiple times
                                              or separate values with commas
+      --github-groups                        Change the delimiters for github to create collapsible groups
+                                             for command output
       --helm-dependency-extra-args strings   Additional arguments for 'helm dependency build' (e.g. ["--skip-refresh"]
       --helm-extra-args string               Additional arguments for Helm. Must be passed as a single quoted string
                                              (e.g. "--timeout 500s"

--- a/doc/ct_lint.md
+++ b/doc/ct_lint.md
@@ -50,6 +50,8 @@ ct lint [flags]
       --exclude-deprecated                   Skip charts that are marked as deprecated
       --excluded-charts strings              Charts that should be skipped. May be specified multiple times
                                              or separate values with commas
+      --github-groups                        Change the delimiters for github to create collapsible groups
+                                             for command output
       --helm-dependency-extra-args strings   Additional arguments for 'helm dependency build' (e.g. ["--skip-refresh"]
       --helm-repo-extra-args strings         Additional arguments for the 'helm repo add' command to be
                                              specified on a per-repo basis with an equals sign as delimiter

--- a/doc/ct_list-changed.md
+++ b/doc/ct_list-changed.md
@@ -20,6 +20,8 @@ ct list-changed [flags]
       --exclude-deprecated        Skip charts that are marked as deprecated
       --excluded-charts strings   Charts that should be skipped. May be specified multiple times
                                   or separate values with commas
+      --github-groups             Change the delimiters for github to create collapsible groups
+                                  for command output
   -h, --help                      help for list-changed
       --print-config              Prints the configuration to stderr (caution: setting this may
                                   expose sensitive data when helm-repo-extra-args contains passwords)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -71,6 +71,7 @@ type Configuration struct {
 	ExcludeDeprecated       bool          `mapstructure:"exclude-deprecated"`
 	KubectlTimeout          time.Duration `mapstructure:"kubectl-timeout"`
 	PrintLogs               bool          `mapstructure:"print-logs"`
+	GithubGroups            bool          `mapstructure:"github-groups"`
 }
 
 func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*Configuration, error) {
@@ -173,9 +174,13 @@ func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*C
 }
 
 func printCfg(cfg *Configuration) {
-	util.PrintDelimiterLineToWriter(os.Stderr, "-")
-	fmt.Fprintln(os.Stderr, " Configuration")
-	util.PrintDelimiterLineToWriter(os.Stderr, "-")
+	if !cfg.GithubGroups {
+		util.PrintDelimiterLineToWriter(os.Stderr, "-")
+		fmt.Fprintln(os.Stderr, " Configuration")
+		util.PrintDelimiterLineToWriter(os.Stderr, "-")
+	} else {
+		util.GithubGroupsBegin(os.Stderr, "Configuration")
+	}
 
 	e := reflect.ValueOf(cfg).Elem()
 	typeOfCfg := e.Type()
@@ -191,7 +196,11 @@ func printCfg(cfg *Configuration) {
 		fmt.Fprintf(os.Stderr, pattern, typeOfCfg.Field(i).Name, e.Field(i).Interface())
 	}
 
-	util.PrintDelimiterLineToWriter(os.Stderr, "-")
+	if !cfg.GithubGroups {
+		util.PrintDelimiterLineToWriter(os.Stderr, "-")
+	} else {
+		util.GithubGroupsEnd(os.Stderr)
+	}
 }
 
 func findConfigFile(fileName string) (string, error) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -219,11 +219,15 @@ func BreakingChangeAllowed(left string, right string) (bool, error) {
 }
 
 func PrintDelimiterLineToWriter(w io.Writer, delimiterChar string) {
-	delim := make([]string, 120)
-	for i := 0; i < 120; i++ {
-		delim[i] = delimiterChar
-	}
-	fmt.Fprintln(w, strings.Join(delim, ""))
+	fmt.Fprintln(w, strings.Repeat(delimiterChar, 120))
+}
+
+func GithubGroupsBegin(w io.Writer, title string) {
+	fmt.Fprintf(w, "::group::%s\n", title)
+}
+
+func GithubGroupsEnd(w io.Writer) {
+	fmt.Fprintln(w, "::endgroup::")
 }
 
 func SanitizeName(s string, maxLength int) string {


### PR DESCRIPTION
see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines

<!--
Thank you for contributing to helm/chart-testing.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
The logging between tests is incredibly verbose. Github has a way of collapsing logs into groups. This takes advantage of that feature.


**Special notes for your reviewer**:
See https://github.com/redpanda-data/helm-charts/actions/runs/5087615217/jobs/9143147560?pr=521#step:15:2372 for an example.