### PR TITLE
fix for ct install getting stuck when printing logs: close readers when done with reading

### DIFF
--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -91,6 +91,8 @@ func (p ProcessExecutor) RunProcess(executable string, execArgs ...interface{}) 
 
 	scanner := bufio.NewScanner(io.MultiReader(outReader, errReader))
 	go func() {
+		defer outReader.Close()
+		defer errReader.Close()
 		for scanner.Scan() {
 			fmt.Println(scanner.Text())
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/chart-testing.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

In some cases `kubectl logs ..` was hanging for us. This mainly happened with pods that logged lines with a lot of characters.

The fix of closing both pipes after reading them successfully did the trick and we weren't getting stuck anymore. 

---
**Which issue this PR fixes** *:

There are some closed issue related to this problem:
- https://github.com/helm/chart-testing/issues/332
- https://github.com/helm/chart-testing/issues/471

**Special notes for your reviewer**:

This is how you can reproduce the stuck kubectl logs:

```sh
git clone git@github.com:ethpandaops/ethereum-helm-charts.git 
cd ethereum-helm-charts
git checkout bbusa/grandine
docker run --rm --network host --workdir /workdir --volume "$HOME/.kube/config:/root/.kube/config:ro" --volume "$(pwd):/workdir" quay.io/helmpack/chart-testing:v3.8.0 ct install --config ct.yaml --charts charts/ethereum-node --helm-extra-set-args="--values=charts/ethereum-node/ci/networks/sepolia.yaml --values=charts/ethereum-node/ci/clients/execution/nethermind.yaml --values=charts/ethereum-node/ci/clients/consensus/grandine.yaml"
```

I've also tried using the kubectl request-timeout to see if the command would exit, but that didn't happen. The only way for it to terminate was to close the io readers. 

Example of a command that got stuck : 

```
kubectl --request-timeout=1m0s logs ethereum-node-si0kgvb2xz-beacon-0 --namespace ethereum-node-si0kgvb2xz --container grandine
```