### PR TITLE
Do not disable version check on one chart

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -161,7 +161,7 @@ func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*C
 		cfg.LintConf = cfgFile
 	}
 
-	if len(cfg.Charts) > 0 || cfg.ProcessAllCharts {
+	if len(cfg.Charts) > 1 || cfg.ProcessAllCharts {
 		fmt.Fprintln(os.Stderr, "Version increment checking disabled.")
 		cfg.CheckVersionIncrement = false
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/chart-testing.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
Because one chart in the configuration could have evaluated version check.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: none

**Special notes for your reviewer**:
Please see conversation in https://github.com/redpanda-data/helm-charts/pull/708#issuecomment-1712455752

Test output
```
$ go build -o ct-binary ./ct/main.go
$ cd ~/redpanda/helm-charts
$ ~/chart-testing/ct-binary lint --config .github/ct-operator.yaml --chart-yaml-schema /opt/homebrew/Cellar/chart-testing/3.9.0/.bottle/etc/ct/chart_schema.yaml --lint-conf /opt/homebrew/Cellar/chart-testing/3.9.0/.bottle/etc/ct/lintconf.yaml

Linting charts...
>>> helm version --template {{ .Version }}

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 operator => (version: "0.3.13", path: "charts/operator")
------------------------------------------------------------------------------------------------------------------------

>>> helm repo add redpanda https://charts.redpanda.com
"redpanda" already exists with the same configuration, skipping
>>> helm dependency build charts/operator
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "jetstack" chart repository
...Successfully got an update from the "prometheus-community" chart repository
...Successfully got an update from the "redpanda" chart repository
...Successfully got an update from the "projectcalico" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 1 charts
Downloading kube-prometheus-stack from repo https://prometheus-community.github.io/helm-charts
Deleting outdated charts
Linting chart "operator => (version: \"0.3.13\", path: \"charts/operator\")"
Checking chart "operator => (version: \"0.3.13\", path: \"charts/operator\")" for a version bump...
>>> git cat-file -e origin/main:charts/operator/Chart.yaml
>>> git show origin/main:charts/operator/Chart.yaml
Old chart version: 0.3.13
New chart version: 0.3.13

------------------------------------------------------------------------------------------------------------------------
 ✖︎ operator => (version: "0.3.13", path: "charts/operator") > chart version not ok. Needs a version bump! 
------------------------------------------------------------------------------------------------------------------------
Error: failed linting charts: failed processing charts
failed linting charts: failed processing charts

```