### PR TITLE
use the same ref to check branch existance and merge-base calculation

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -722,11 +722,12 @@ func (t *Testing) computeMergeBase() (string, error) {
 		return "", errors.New("must be in a git repository")
 	}
 
-	if !t.git.BranchExists(t.config.TargetBranch) {
-		return "", fmt.Errorf("targetBranch '%s' does not exist", t.config.TargetBranch)
+	branch := fmt.Sprintf("%s/%s", t.config.Remote, t.config.TargetBranch)
+	if !t.git.BranchExists(branch) {
+		return "", fmt.Errorf("targetBranch '%s' does not exist", branch)
 	}
 
-	return t.git.MergeBase(fmt.Sprintf("%s/%s", t.config.Remote, t.config.TargetBranch), t.config.Since)
+	return t.git.MergeBase(branch, t.config.Since)
 }
 
 // ComputeChangedChartDirectories takes the merge base of HEAD and the configured remote and target branch and computes a


### PR DESCRIPTION
<!--
Thank you for contributing to helm/chart-testing.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

#511 added the BranchExists check, but it used the value of --target-branch while MergeBase used the compound value of --remote/--target-branch

this PR changes BranchExists to use the same value as MergeBase.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #577   #580


**Special notes for your reviewer**:
