### PR TITLE
Fix for `--upgrade` option

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -369,7 +369,7 @@ func (t *Testing) processCharts(action func(chart *Chart) TestResult) ([]TestRes
 			return results, fmt.Errorf("failed identifying merge base: %w", err)
 		}
 		// Add worktree for the target revision
-		worktreePath, err := os.MkdirTemp("./", "ct_previous_revision")
+		worktreePath, err := os.MkdirTemp("./", "ct-previous-revision")
 		if err != nil {
 			return results, fmt.Errorf("could not create previous revision directory: %w", err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**: 

Currently `ct install` with `--upgrade` option is broken. It copies the chart into the `ct_previous_revision` directory, and when it executes `helm install ./ct_previous_revision` it fails with the "wrong release name" error:

```
Testing upgrades of chart "chart-name => (version: \"0.0.1\", path: \".\")" relative to previous revision "chart-name => (version: \"0.0.1\", path: \"ct_previous_revision7182718172\")"...

Installing chart "chart-name => (version: \"0.0.1\", path: \"ct_previous_revision7182718172\")" with values file "ct_previous_revision7182718172/ci/test.yaml"...

Error: INSTALLATION FAILED: release name "ct_previous_revision7182718172-hehs72hayw": invalid release name, must match regex ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ and the length must not be longer than 53
Upgrade testing for release "ct_previous_revision7182718172-hehs72hayw" skipped because of previous revision installation error: failed waiting for process: exit status 1
```

Replacing underscores with dashes is the simplest way to solve this issue.