### PR TITLE
Add missing `helm-extra-set-args` configuration flag

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,6 +61,7 @@ type Configuration struct {
 	ChartDirs               []string      `mapstructure:"chart-dirs"`
 	ExcludedCharts          []string      `mapstructure:"excluded-charts"`
 	HelmExtraArgs           string        `mapstructure:"helm-extra-args"`
+	HelmExtraSetArgs        string        `mapstructure:"helm-extra-set-args"`
 	HelmLintExtraArgs       string        `mapstructure:"helm-lint-extra-args"`
 	HelmRepoExtraArgs       []string      `mapstructure:"helm-repo-extra-args"`
 	HelmDependencyExtraArgs []string      `mapstructure:"helm-dependency-extra-args"`


### PR DESCRIPTION
<!--
Thank you for contributing to helm/chart-testing.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

This should allow defining `helm-extra-set-args` within the config file or as an environment variable.
That flag was introduced by https://github.com/helm/chart-testing/pull/402

**Special notes for your reviewer**:

I hope this is sufficient, but please tell me if additional changes need to be applied to make this flag as generic as the others.