### PR TITLE
Fix `helm-extra-set-args` in YAML configuration

### DIFF
--- a/ct/cmd/install.go
+++ b/ct/cmd/install.go
@@ -96,11 +96,7 @@ func install(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed loading configuration: %w", err)
 	}
 
-	extraSetArgs, err := cmd.Flags().GetString("helm-extra-set-args")
-	if err != nil {
-		return err
-	}
-	testing, err := chart.NewTesting(*configuration, extraSetArgs)
+	testing, err := chart.NewTesting(*configuration)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/ct/cmd/lint.go
+++ b/ct/cmd/lint.go
@@ -90,8 +90,7 @@ func lint(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed loading configuration: %w", err)
 	}
 
-	emptyExtraSetArgs := ""
-	testing, err := chart.NewTesting(*configuration, emptyExtraSetArgs)
+	testing, err := chart.NewTesting(*configuration)
 	if err != nil {
 		return err
 	}

--- a/ct/cmd/lintAndInstall.go
+++ b/ct/cmd/lintAndInstall.go
@@ -51,11 +51,7 @@ func lintAndInstall(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed loading configuration: %w", err)
 	}
 
-	extraSetArgs, err := cmd.Flags().GetString("helm-extra-set-args")
-	if err != nil {
-		return err
-	}
-	testing, err := chart.NewTesting(*configuration, extraSetArgs)
+	testing, err := chart.NewTesting(*configuration)
 	if err != nil {
 		return err
 	}

--- a/ct/cmd/listChanged.go
+++ b/ct/cmd/listChanged.go
@@ -50,8 +50,7 @@ func listChanged(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed loading configuration: %w", err)
 	}
 
-	emptyExtraSetArgs := ""
-	testing, err := chart.NewTesting(*configuration, emptyExtraSetArgs)
+	testing, err := chart.NewTesting(*configuration)
 	if err != nil {
 		return err
 	}

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -266,14 +266,15 @@ type TestResult struct {
 }
 
 // NewTesting creates a new Testing struct with the given config.
-func NewTesting(config config.Configuration, extraSetArgs string) (Testing, error) {
+func NewTesting(config config.Configuration) (Testing, error) {
 	procExec := exec.NewProcessExecutor(config.Debug)
 	helmExtraArgs := strings.Fields(config.HelmExtraArgs)
+	helmExtraSetArgs := strings.Fields(config.HelmExtraSetArgs)
 	helmLintExtraArgs := strings.Fields(config.HelmLintExtraArgs)
 
 	testing := Testing{
 		config:           config,
-		helm:             tool.NewHelm(procExec, helmExtraArgs, helmLintExtraArgs, strings.Fields(extraSetArgs)),
+		helm:             tool.NewHelm(procExec, helmExtraArgs, helmLintExtraArgs, helmExtraSetArgs),
 		git:              tool.NewGit(procExec),
 		kubectl:          tool.NewKubectl(procExec, config.KubectlTimeout),
 		linter:           tool.NewLinter(procExec),


### PR DESCRIPTION
**What this PR does / why we need it:**

Allows the usage of `helm-extra-set-args` key from a `ct.yaml` and not just command-line flags. 

Currently, `helm-extra-set-args` is only available as a command-line flag, despite being part of the config object. This does not appear to be documented.

This change sources the value `extraSetArgs` via the `config` object rather than the cmd.Flags() only.

This PR adds the configuration option but it is never used: https://github.com/helm/chart-testing/pull/697
