### PR TITLE
feat: add --wait flag to helm uninstall

### DIFF
--- a/pkg/tool/helm.go
+++ b/pkg/tool/helm.go
@@ -86,7 +86,7 @@ func (h Helm) Test(namespace string, release string) error {
 
 func (h Helm) DeleteRelease(namespace string, release string) {
 	fmt.Printf("Deleting release %q...\n", release)
-	if err := h.exec.RunProcess("helm", "uninstall", release, "--namespace", namespace, h.extraArgs); err != nil {
+	if err := h.exec.RunProcess("helm", "uninstall", release, "--namespace", namespace, "--wait", h.extraArgs); err != nil {
 		fmt.Println("Error deleting Helm release:", err)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, the `helm uninstall` command does not use a `--wait` flag, unlike the `helm install` and `helm upgrade` commands. This can lead to issues, specifically with `ct install --upgrade`, where certain resources (in our case, namespaces other than the release namespace) have not yet been fully deleted from the kubernetes cluster, despite the `helm uninstall` command having exited successfully. This is causing the subsequent `helm install` to fail.

By forcing `helm uninstall` to wait, these race conditions should not be an issue.

**Special notes for your reviewer**:

We considered using `helm-set-args '--wait'` to achieve this, but the `helm test` command does not recognize the `--wait`  flag and therefore fails. A less clean but less heavy-handed approach could be to strip the `--wait` flag before running `helm test`.