### PR TITLE
Fix chart_schema.yaml import-values rule

### DIFF
--- a/etc/chart_schema.yaml
+++ b/etc/chart_schema.yaml
@@ -29,7 +29,7 @@ dependency:
   condition: str(required=False)
   tags: list(str(), required=False)
   enabled: bool(required=False)
-  import-values: any(list(str()), list(include('import-value')), required=False)
+  import-values: list(any(str(), include('import-value')), required=False)
   alias: str(required=False)
 ---
 import-value:


### PR DESCRIPTION
**What this PR does / why we need it**:

The existing rule for validating dependency import-values worked well for either of these two cases:

**1. Importing exports**

```yaml
dependencies:
- name: dep1
  version: 0.14.1
  repository: oci://myrepo
  import-values:
    - data
```

**2. Importing child values into the parent**

```yaml
dependencies:
- name: dep1
  version: 0.14.1
  repository: oci://myrepo
  import-values:
    - child: default.data
      parent: myimports
```

However, it failed on the following valid usecase:

```yaml
dependencies:
- name: dep1
  version: 0.14.1
  repository: oci://myrepo
  import-values:
    - data
    - child: default.data
      parent: myimports
```

Giving the following error:

```
dependencies.0.import-values.1: '{'parent': 'myimports', 'child': 'default.data'}' is not a str.
dependencies.0.import-values.0 : 'data' is not a map
```

This is because the Yamale is validating on a list of strings *or* a list of `import-value`, where a list containing both is also valid.

This commit changes the rule to allow both methods to be in the `import-values` list.