### PR TITLE
Add release-name option

### DIFF
--- a/ct/cmd/install.go
+++ b/ct/cmd/install.go
@@ -71,6 +71,9 @@ func addInstallFlags(flags *flag.FlagSet) {
 	flags.String("namespace", "", heredoc.Doc(`
 		Namespace to install the release(s) into. If not specified, each release will be
 		installed in its own randomly generated namespace`))
+	flags.String("release-name", "", heredoc.Doc(`
+		Name for the release. If not specified, is set to the chart name and a random 
+		identifier.`))
 	flags.String("release-label", "app.kubernetes.io/instance", heredoc.Doc(`
 		The label to be used as a selector when inspecting resources created by charts.
 		This is only used if namespace is specified`))

--- a/doc/ct_install.md
+++ b/doc/ct_install.md
@@ -68,6 +68,8 @@ ct install [flags]
                                              expose sensitive data when helm-repo-extra-args contains passwords)
       --release-label string                 The label to be used as a selector when inspecting resources created by charts.
                                              This is only used if namespace is specified (default "app.kubernetes.io/instance")
+      --release-name string                  Name for the release. If not specified, is set to the chart name and a random 
+                                             identifier.
       --remote string                        The name of the Git remote used to identify changed charts (default "origin")
       --since string                         The Git reference used to identify changed charts (default "HEAD")
       --skip-clean-up                        Skip resources clean-up. Used if need to continue other flows or keep it around.

--- a/doc/ct_lint-and-install.md
+++ b/doc/ct_lint-and-install.md
@@ -63,6 +63,8 @@ ct lint-and-install [flags]
                                              expose sensitive data when helm-repo-extra-args contains passwords)
       --release-label string                 The label to be used as a selector when inspecting resources created by charts.
                                              This is only used if namespace is specified (default "app.kubernetes.io/instance")
+      --release-name string                  Name for the release. If not specified, is set to the chart name and a random 
+                                             identifier.
       --remote string                        The name of the Git remote used to identify changed charts (default "origin")
       --since string                         The Git reference used to identify changed charts (default "HEAD")
       --skip-clean-up                        Skip resources clean-up. Used if need to continue other flows or keep it around.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -70,6 +70,7 @@ type Configuration struct {
 	SkipMissingValues       bool          `mapstructure:"skip-missing-values"`
 	SkipCleanUp             bool          `mapstructure:"skip-clean-up"`
 	Namespace               string        `mapstructure:"namespace"`
+	ReleaseName             string        `mapstructure:"release-name"`
 	ReleaseLabel            string        `mapstructure:"release-label"`
 	ExcludeDeprecated       bool          `mapstructure:"exclude-deprecated"`
 	KubectlTimeout          time.Duration `mapstructure:"kubectl-timeout"`


### PR DESCRIPTION
**What this PR does / why we need it**: Adds an additional option for release name. Allows charts with long names and additional resources that may append more length to the release name to work with kubernetes 63 character limitation. 

**Which issue this PR fixes** : fixes #343 , #734 

**Special notes for your reviewer**: 
