### PR TITLE
fix(upgrade): using the values instead of --reuse-values

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -79,7 +79,8 @@ type Git interface {
 // InstallWithValues runs `helm install` for the given chart using the specified values file.
 // Pass a zero value for valuesFile in order to run install without specifying a values file.
 //
-// Upgrade runs `helm upgrade` against an existing release, and re-uses the previously computed values.
+// UpgradeWithValues runs `helm upgrade` against an existing release using the specified values file.
+// Pass a zero value for valuesFile in order to run install without specifying a values file.
 //
 // Test runs `helm test` against an existing release. Set the cleanup argument to true in order
 // to clean up test pods created by helm after the test command completes.
@@ -91,7 +92,7 @@ type Helm interface {
 	BuildDependenciesWithArgs(chart string, extraArgs []string) error
 	LintWithValues(chart string, valuesFile string) error
 	InstallWithValues(chart string, valuesFile string, namespace string, release string) error
-	Upgrade(chart string, namespace string, release string) error
+	UpgradeWithValues(chart string, valuesFile string, namespace string, release string) error
 	Test(namespace string, release string) error
 	DeleteRelease(namespace string, release string)
 	Version() (string, error)
@@ -660,7 +661,7 @@ func (t *Testing) doUpgrade(oldChart, newChart *Chart, oldChartMustPass bool) er
 				return nil
 			}
 
-			if err := t.helm.Upgrade(newChart.Path(), namespace, release); err != nil {
+			if err := t.helm.UpgradeWithValues(newChart.Path(), valuesFile, namespace, release); err != nil {
 				return err
 			}
 

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -111,7 +111,7 @@ func (h *fakeHelm) LintWithValues(_ string, _ string) error { return nil }
 func (h *fakeHelm) InstallWithValues(_ string, _ string, _ string, _ string) error {
 	return nil
 }
-func (h *fakeHelm) Upgrade(_ string, _ string, _ string) error {
+func (h *fakeHelm) UpgradeWithValues(_ string, _ string, _ string, _ string) error {
 	return nil
 }
 func (h *fakeHelm) Test(_ string, _ string) error {

--- a/pkg/tool/helm.go
+++ b/pkg/tool/helm.go
@@ -75,9 +75,14 @@ func (h Helm) InstallWithValues(chart string, valuesFile string, namespace strin
 		"--wait", values, h.extraArgs, h.extraSetArgs)
 }
 
-func (h Helm) Upgrade(chart string, namespace string, release string) error {
+func (h Helm) UpgradeWithValues(chart string, valuesFile string, namespace string, release string) error {
+	var values []string
+	if valuesFile != "" {
+		values = []string{"--values", valuesFile}
+	}
+
 	return h.exec.RunProcess("helm", "upgrade", release, chart, "--namespace", namespace,
-		"--reuse-values", "--wait", h.extraArgs, h.extraSetArgs)
+		"--wait", values, h.extraArgs, h.extraSetArgs)
 }
 
 func (h Helm) Test(namespace string, release string) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
The `ct` tool is leveraging the `--reuse-value` values flag that is a bit controversial since it does not leverage the new values in the values.yaml. https://github.com/helm/helm/issues/8085 https://github.com/helm/helm/issues/3957
This causes many pipeline to fail with false positives (each time you add a new default)


Currently, there is available different flags that overcome that issue "--reset-then-reuse-values", however I think it is better to actually use the values that are available instead of rely on a different flag that might be not available in all Helm versions.




