### PR TITLE
chore: update GoReleaser configurations

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,7 +36,8 @@ builds:
 archives:
   - format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
     files:
       - LICENSE
       - README.md


### PR DESCRIPTION
# Description
This small PR updates the GoReleaser configuration to resolve the following warnings, which you can find in the [CI logs](https://github.com/helm/chart-testing/actions/runs/16744911890/job/47401055225#step:15:26): 
```
DEPRECATED: archives.format_overrides.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
```
