### PR TITLE
chore: bump to Go 1.26, harden release workflow, tidy code

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           check-latest: true
           cache: false
 
@@ -99,7 +99,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           check-latest: true
           cache: false
 
@@ -128,11 +128,11 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           check-latest: true
           cache: false
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.7
+          version: v2.12

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: true
 
       - name: shellcheck
         uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # v2.0.0
@@ -69,20 +70,23 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Tag
+        env:
+          INPUTS_VERSION: ${{ github.event.inputs.version }}
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-          tag='${{ github.event.inputs.version }}'
+          tag="${INPUTS_VERSION}"
           git tag --annotate --message "Tag for release $tag" "$tag"
           git push origin "refs/tags/$tag"
 
       - name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUTS_VERSION: ${{ github.event.inputs.version }}
         run: |
           set -o nounset
           set -o pipefail
 
-          echo "Building release ${{ github.event.inputs.version }}"
+          echo "Building release ${INPUTS_VERSION}"
           ./build.sh --release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           check-latest: true
           cache: false
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/helm/chart-testing/v3
 
-go 1.25.0
+go 1.26
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/Masterminds/semver"
@@ -144,7 +145,7 @@ type Linter interface {
 //
 // RunCommand renders cmdTemplate as go template using data and executes the resulting command
 type CmdExecutor interface {
-	RunCommand(cmdTemplate string, data interface{}) error
+	RunCommand(cmdTemplate string, data any) error
 }
 
 // DirectoryLister is the interface
@@ -251,12 +252,6 @@ type Testing struct {
 	utils                    Utils
 	previousRevisionWorktree string
 	loadRules                func(string) (*helmignore.Rules, error)
-}
-
-// TestResults holds results and overall status
-type TestResults struct {
-	OverallSuccess bool
-	TestResults    []TestResult
 }
 
 // TestResult holds test results for a specific chart
@@ -368,10 +363,7 @@ func (t *Testing) processCharts(action func(chart *Chart) TestResult) ([]TestRes
 		}
 	}
 
-	testResults := TestResults{
-		OverallSuccess: true,
-		TestResults:    results,
-	}
+	overallSuccess := true
 
 	// Checkout previous chart revisions and build their dependencies
 	if t.config.Upgrade {
@@ -410,11 +402,11 @@ func (t *Testing) processCharts(action func(chart *Chart) TestResult) ([]TestRes
 
 		result := action(chart)
 		if result.Error != nil {
-			testResults.OverallSuccess = false
+			overallSuccess = false
 		}
 		results = append(results, result)
 	}
-	if testResults.OverallSuccess {
+	if overallSuccess {
 		return results, nil
 	}
 
@@ -764,7 +756,7 @@ func (t *Testing) ComputeChangedChartDirectories() ([]string, error) {
 	changedChartFiles := map[string][]string{}
 	for _, file := range allChangedChartFiles {
 		pathElements := strings.SplitN(filepath.ToSlash(file), "/", 3)
-		if len(pathElements) < 2 || util.StringSliceContains(cfg.ExcludedCharts, pathElements[1]) {
+		if len(pathElements) < 2 || slices.Contains(cfg.ExcludedCharts, pathElements[1]) {
 			continue
 		}
 		dir := filepath.Dir(file)
@@ -774,7 +766,7 @@ func (t *Testing) ComputeChangedChartDirectories() ([]string, error) {
 		if err == nil {
 			if len(chartDirElement) > 1 {
 				chartDirName := chartDirElement[len(chartDirElement)-1]
-				if util.StringSliceContains(cfg.ExcludedCharts, chartDirName) {
+				if slices.Contains(cfg.ExcludedCharts, chartDirName) {
 					continue
 				}
 			}
@@ -818,7 +810,7 @@ func (t *Testing) ReadAllChartDirectories() ([]string, error) {
 		dirs, err := t.directoryLister.ListChildDirs(chartParentDir,
 			func(dir string) bool {
 				_, err := t.utils.LookupChartDir(cfg.ChartDirs, dir)
-				return err == nil && !util.StringSliceContains(cfg.ExcludedCharts, filepath.Base(dir))
+				return err == nil && !slices.Contains(cfg.ExcludedCharts, filepath.Base(dir))
 			})
 		if err != nil {
 			return nil, fmt.Errorf("failed reading chart directories: %w", err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -90,7 +90,7 @@ func LoadConfiguration(cfgFile string, cmd *cobra.Command, printConfig bool) (*C
 		if flagName != "config" && flagName != "help" {
 			if err := v.BindPFlag(flagName, flag); err != nil {
 				// can't really happen
-				panic(fmt.Sprintf("failed binding flag %q: %v\n", flagName, err.Error()))
+				panic(fmt.Sprintf("failed binding flag %q: %v\n", flagName, err))
 			}
 		}
 	})

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -15,7 +15,6 @@
 package config
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -34,6 +33,7 @@ func TestUnmarshalJson(t *testing.T) {
 }
 
 func loadAndAssertConfigFromFile(t *testing.T, configFile string) {
+	t.Helper()
 	cfg, _ := LoadConfiguration(configFile, &cobra.Command{
 		Use: "install",
 	}, true)
@@ -43,25 +43,25 @@ func loadAndAssertConfigFromFile(t *testing.T, configFile string) {
 	require.Equal(t, "pr-42", cfg.BuildID)
 	require.Equal(t, "my-lint-conf.yaml", cfg.LintConf)
 	require.Equal(t, "my-chart-yaml-schema.yaml", cfg.ChartYamlSchema)
-	require.Equal(t, true, cfg.ValidateMaintainers)
-	require.Equal(t, true, cfg.ValidateChartSchema)
-	require.Equal(t, true, cfg.ValidateYaml)
-	require.Equal(t, true, cfg.CheckVersionIncrement)
-	require.Equal(t, false, cfg.ProcessAllCharts)
+	require.True(t, cfg.ValidateMaintainers)
+	require.True(t, cfg.ValidateChartSchema)
+	require.True(t, cfg.ValidateYaml)
+	require.True(t, cfg.CheckVersionIncrement)
+	require.False(t, cfg.ProcessAllCharts)
 	require.Equal(t, []string{"incubator=https://incubator"}, cfg.ChartRepos)
 	require.Equal(t, []string{"incubator=--username test"}, cfg.HelmRepoExtraArgs)
 	require.Equal(t, []string{"stable", "incubator"}, cfg.ChartDirs)
 	require.Equal(t, []string{"common"}, cfg.ExcludedCharts)
 	require.Equal(t, "--timeout 300s", cfg.HelmExtraArgs)
 	require.Equal(t, "--quiet", cfg.HelmLintExtraArgs)
-	require.Equal(t, true, cfg.Upgrade)
-	require.Equal(t, true, cfg.SkipMissingValues)
+	require.True(t, cfg.Upgrade)
+	require.True(t, cfg.SkipMissingValues)
 	require.Equal(t, "default", cfg.Namespace)
 	require.Equal(t, "release", cfg.ReleaseLabel)
-	require.Equal(t, true, cfg.ExcludeDeprecated)
+	require.True(t, cfg.ExcludeDeprecated)
 	require.Equal(t, 120*time.Second, cfg.KubectlTimeout)
-	require.Equal(t, true, cfg.SkipCleanUp)
-	require.Equal(t, true, cfg.UseHelmignore)
+	require.True(t, cfg.SkipCleanUp)
+	require.True(t, cfg.UseHelmignore)
 }
 
 func Test_findConfigFile(t *testing.T) {
@@ -96,13 +96,7 @@ func Test_findConfigFile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.envVar != "" {
-				err := os.Setenv("CT_CONFIG_DIR", tt.envVar)
-				require.NoError(t, err)
-
-				t.Cleanup(func() {
-					err := os.Unsetenv("CT_CONFIG_DIR")
-					require.NoError(t, err)
-				})
+				t.Setenv("CT_CONFIG_DIR", tt.envVar)
 			}
 			configSearchLocations = []string{tt.defaultDir}
 

--- a/pkg/tool/kubectl.go
+++ b/pkg/tool/kubectl.go
@@ -78,7 +78,7 @@ func (k Kubectl) forceNamespaceDeletion(namespace string) error {
 		return err
 	}
 
-	namespaceUpdate := map[string]interface{}{}
+	namespaceUpdate := map[string]any{}
 	err = json.Unmarshal([]byte(cmdOutput), &namespaceUpdate)
 	if err != nil {
 		fmt.Println("Error in unmarshalling the payload:", err)
@@ -154,8 +154,7 @@ func (k Kubectl) WaitForDeployments(namespace string, selector string) error {
 		return err
 	}
 
-	deployments := strings.Fields(output)
-	for _, deployment := range deployments {
+	for deployment := range strings.FieldsSeq(output) {
 		deployment = strings.Trim(deployment, "'")
 		err = k.exec.RunProcess("kubectl",
 			fmt.Sprintf("--request-timeout=%s", k.timeout),
@@ -188,15 +187,15 @@ func (k Kubectl) GetPodsforDeployment(namespace string, deployment string) ([]st
 	jsonString, _ := k.exec.RunProcessAndCaptureStdout("kubectl",
 		fmt.Sprintf("--request-timeout=%s", k.timeout),
 		"get", "deployment", deployment, "--namespace", namespace, "--output=json")
-	var deploymentMap map[string]interface{}
+	var deploymentMap map[string]any
 	err := json.Unmarshal([]byte(jsonString), &deploymentMap)
 	if err != nil {
 		return nil, err
 	}
 
-	spec := deploymentMap["spec"].(map[string]interface{})
-	selector := spec["selector"].(map[string]interface{})
-	matchLabels := selector["matchLabels"].(map[string]interface{})
+	spec := deploymentMap["spec"].(map[string]any)
+	selector := spec["selector"].(map[string]any)
+	matchLabels := selector["matchLabels"].(map[string]any)
 	var ls string
 	for name, value := range matchLabels {
 		if ls != "" {
@@ -209,7 +208,8 @@ func (k Kubectl) GetPodsforDeployment(namespace string, deployment string) ([]st
 }
 
 func (k Kubectl) GetPods(args ...string) ([]string, error) {
-	kubectlArgs := []string{"get", "pods"}
+	kubectlArgs := make([]string, 0, 2+len(args))
+	kubectlArgs = append(kubectlArgs, "get", "pods")
 	kubectlArgs = append(kubectlArgs, args...)
 	pods, err := k.exec.RunProcessAndCaptureStdout("kubectl",
 		fmt.Sprintf("--request-timeout=%s", k.timeout), kubectlArgs)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -25,7 +25,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"time"
 
 	"github.com/Masterminds/semver"
 	"github.com/hashicorp/go-multierror"
@@ -46,15 +45,11 @@ type ChartYaml struct {
 	Maintainers []Maintainer
 }
 
-func Flatten(items []interface{}) ([]string, error) {
+func Flatten(items []any) ([]string, error) {
 	return doFlatten([]string{}, items)
 }
 
-func init() {
-	rand.New(rand.NewSource(time.Now().UnixNano())) // nolint: gosec
-}
-
-func doFlatten(result []string, items interface{}) ([]string, error) {
+func doFlatten(result []string, items any) ([]string, error) {
 	var err error
 
 	switch v := items.(type) {
@@ -62,7 +57,7 @@ func doFlatten(result []string, items interface{}) ([]string, error) {
 		result = append(result, v)
 	case []string:
 		result = append(result, v...)
-	case []interface{}:
+	case []any:
 		for _, item := range v {
 			result, err = doFlatten(result, item)
 			if err != nil {
@@ -74,15 +69,6 @@ func doFlatten(result []string, items interface{}) ([]string, error) {
 	}
 
 	return result, err
-}
-
-func StringSliceContains(slice []string, s string) bool {
-	for _, element := range slice {
-		if s == element {
-			return true
-		}
-	}
-	return false
 }
 
 func FileExists(file string) bool {
@@ -243,10 +229,10 @@ func SanitizeName(s string, maxLength int) string {
 
 func GetRandomPort() (int, error) {
 	listener, err := net.Listen("tcp", ":0") // nolint: gosec
-	defer listener.Close()                   // nolint: staticcheck
 	if err != nil {
 		return 0, err
 	}
+	defer listener.Close() // nolint: errcheck
 
 	return listener.Addr().(*net.TCPAddr).Port, nil
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -24,13 +24,13 @@ import (
 
 func TestFlatten(t *testing.T) {
 	var testDataSlice = []struct {
-		input    []interface{}
+		input    []any
 		expected []string
 	}{
-		{[]interface{}{"foo", "bar", []string{"bla", "blubb"}}, []string{"foo", "bar", "bla", "blubb"}},
-		{[]interface{}{"foo", "bar", "bla", "blubb"}, []string{"foo", "bar", "bla", "blubb"}},
-		{[]interface{}{"foo", "bar", []interface{}{"bla", []string{"blubb"}}}, []string{"foo", "bar", "bla", "blubb"}},
-		{[]interface{}{"foo", 42, []interface{}{"bla", []string{"blubb"}}}, nil},
+		{[]any{"foo", "bar", []string{"bla", "blubb"}}, []string{"foo", "bar", "bla", "blubb"}},
+		{[]any{"foo", "bar", "bla", "blubb"}, []string{"foo", "bar", "bla", "blubb"}},
+		{[]any{"foo", "bar", []any{"bla", []string{"blubb"}}}, []string{"foo", "bar", "bla", "blubb"}},
+		{[]any{"foo", 42, []any{"bla", []string{"blubb"}}}, nil},
 	}
 
 	for index, testData := range testDataSlice {
@@ -38,9 +38,9 @@ func TestFlatten(t *testing.T) {
 			actual, err := Flatten(testData.input)
 			assert.Equal(t, testData.expected, actual)
 			if testData.expected != nil {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			} else {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
- Go 1.26 + golangci-lint v2.12 in CI and go.mod
- Quote workflow_dispatch input via env var; set persist-credentials
  explicitly on checkout
- Code/test cleanup across pkg/{chart,config,tool,util}: drop dead
  rand init, swap StringSliceContains for slices.Contains, fix
  defer-before-nil-check in GetRandomPort, remove unused TestResults
  struct, interface{}→any, t.Setenv/t.Helper/require.True