### PR TITLE
fix: propagate kubectl error in GetPodsforDeployment, compile regexp once

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -846,7 +846,7 @@ func (t *Testing) CheckVersionIncrement(chart *Chart) error {
 	}
 
 	if result >= 0 {
-		return errors.New("chart version not ok. Needs a version bump! ")
+		return errors.New("chart version not ok. Needs a version bump!")
 	}
 
 	fmt.Println("Chart version ok.")

--- a/pkg/tool/kubectl.go
+++ b/pkg/tool/kubectl.go
@@ -184,12 +184,14 @@ func (k Kubectl) WaitForDeployments(namespace string, selector string) error {
 }
 
 func (k Kubectl) GetPodsforDeployment(namespace string, deployment string) ([]string, error) {
-	jsonString, _ := k.exec.RunProcessAndCaptureStdout("kubectl",
+	jsonString, err := k.exec.RunProcessAndCaptureStdout("kubectl",
 		fmt.Sprintf("--request-timeout=%s", k.timeout),
 		"get", "deployment", deployment, "--namespace", namespace, "--output=json")
-	var deploymentMap map[string]any
-	err := json.Unmarshal([]byte(jsonString), &deploymentMap)
 	if err != nil {
+		return nil, err
+	}
+	var deploymentMap map[string]any
+	if err := json.Unmarshal([]byte(jsonString), &deploymentMap); err != nil {
 		return nil, err
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -33,6 +33,8 @@ import (
 
 const chars = "1234567890abcdefghijklmnopqrstuvwxyz"
 
+var sanitizeNameRe = regexp.MustCompile("^[^a-zA-Z0-9]+")
+
 type Maintainer struct {
 	Name  string `yaml:"name"`
 	Email string `yaml:"email"`
@@ -217,14 +219,12 @@ func GithubGroupsEnd(w io.Writer) {
 }
 
 func SanitizeName(s string, maxLength int) string {
-	reg := regexp.MustCompile("^[^a-zA-Z0-9]+")
-
 	excess := len(s) - maxLength
 	result := s
 	if excess > 0 {
 		result = s[excess:]
 	}
-	return reg.ReplaceAllString(result, "")
+	return sanitizeNameRe.ReplaceAllString(result, "")
 }
 
 func GetRandomPort() (int, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Two small fixes:

1. `GetPodsforDeployment` was silently dropping the error from `kubectl get deployment`. When kubectl fails you'd get a confusing `unexpected end of JSON input` instead of the actual error. One-liner fix - just stop ignoring the err.

2. `SanitizeName` was calling `regexp.MustCompile` on every invocation. The regex is constant so it should be compiled once at package level (same pattern already used in `account.go` right next door).

Bonus: trimmed a stray trailing space off an error string in `CheckVersionIncrement`.

**How to reproduce**:

For (1): call `GetPodsforDeployment` with a deployment name that doesn't exist or when kubectl isn't configured - you'll see `unexpected end of JSON input` instead of the real kubectl error.

For (2): `SanitizeName` is called in `CreateInstallParams` for every chart install, so the regex gets recompiled on each run. No functional impact but wasteful.

**Special notes for your reviewer**:

All existing tests pass, no behavior change for (2) and (3), (1) now surfaces the real error earlier.