### PR TITLE
fix: honor --release-name instead of generating a random release name

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -207,24 +207,29 @@ func (c *Chart) HasCIValuesFile(path string) bool {
 }
 
 // CreateInstallParams generates a randomized release name and namespace based on the chart path
-// and optional buildID. If release_name is specified, the release name is set to that string instead.
+// and optional buildID. If releaseName is non-empty it is used verbatim as the release name
+// (Helm validates release-name syntax); otherwise a randomized "<name>-<suffix>" form is used.
 // If a buildID is specified, it will be part of the generated namespace.
 func (c *Chart) CreateInstallParams(buildID string, releaseName string) (release string, namespace string) {
 	release = filepath.Base(c.Path())
 	if release == "." || release == "/" {
-		if releaseName != "" {
-			release = releaseName
-		} else {
-			yaml := c.Yaml()
-			release = yaml.Name
-		}
+		yaml := c.Yaml()
+		release = yaml.Name
 	}
 	namespace = release
 	if buildID != "" {
 		namespace = fmt.Sprintf("%s-%s", namespace, buildID)
 	}
 	randomSuffix := util.RandomString(10)
-	release = util.SanitizeName(fmt.Sprintf("%s-%s", release, randomSuffix), maxNameLength)
+	if releaseName != "" {
+		// An explicit --release-name is used verbatim so the release name is
+		// stable and predictable. Previously it was honored only when the chart
+		// path resolved to "." or "/", and a random suffix was appended
+		// unconditionally, which made --release-name appear to be ignored (#198).
+		release = releaseName
+	} else {
+		release = util.SanitizeName(fmt.Sprintf("%s-%s", release, randomSuffix), maxNameLength)
+	}
 	namespace = util.SanitizeName(fmt.Sprintf("%s-%s", namespace, randomSuffix), maxNameLength)
 	return
 }

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -569,3 +569,23 @@ func TestChart_AdditionalCommandsAreRun(t *testing.T) {
 		})
 	}
 }
+
+func TestChart_CreateInstallParams(t *testing.T) {
+	chrt, err := NewChart("test_charts/simple-deployment")
+	assert.Nil(t, err)
+
+	// An explicit release name (--release-name) must be used verbatim, with no
+	// random suffix appended, so the resulting release name is stable and
+	// predictable (#198).
+	release, namespace := chrt.CreateInstallParams("build-id", "my-release")
+	assert.Equal(t, "my-release", release)
+	// The namespace is still derived from the chart directory and randomized,
+	// independent of --release-name.
+	assert.True(t, strings.HasPrefix(namespace, "simple-deployment-build-id-"))
+	assert.NotEqual(t, "my-release", namespace)
+
+	// Without a release name the release keeps its historical randomized form.
+	release, _ = chrt.CreateInstallParams("", "")
+	assert.True(t, strings.HasPrefix(release, "simple-deployment-"))
+	assert.NotEqual(t, "simple-deployment", release)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

`ct install --release-name <name>` was ignored. `Chart.CreateInstallParams` only honored the release name when the chart path resolved to `.` or `/`, and unconditionally appended a random suffix — so `--release-name go-backend` still produced `helm install go-backend-<random>` (see the reproduction in the issue). This uses the provided `--release-name` verbatim as the release name (Helm validates the syntax). The namespace derivation is unchanged.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #198

**Special notes for your reviewer**:

- New unit test `TestChart_CreateInstallParams` in `pkg/chart/chart_test.go` (fails before the fix: the release came out as `simple-deployment-<random>` instead of `my-release`).
- `go test ./...`, `go vet ./pkg/chart/`, `gofmt -l`, and `golangci-lint run ./pkg/chart/...` are all clean locally.
- Namespace behavior is intentionally unchanged: with `--namespace go-backend --release-name go-backend` the caller now yields `helm install go-backend --namespace go-backend`.
